### PR TITLE
Add terraform support to deploy the app on AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 backend/__pycache__/
+terraform/.terraform/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BACKEND_DIR=backend
 REQUIREMENTS=$(BACKEND_DIR)/requirements.txt
 FRONTEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend
 BACKEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend
+VERSION=v0.0.2
+BUCKET_NAME=shrubb-ai-stock-analyzer-frontend
+DIST_DIR=frontend/dist
 
 .PHONY: venv
 venv:
@@ -44,6 +47,23 @@ frontend-deps:
 frontend-build:
 	cd frontend && npm run build
 
+# Upload dist/ folder to S3
+.PHONY: frontend-upload
+frontend-upload:
+	@echo "🚀 Uploading to S3 bucket $(BUCKET_NAME)..."
+	aws s3 sync $(DIST_DIR)/ s3://$(BUCKET_NAME) --delete
+
+# Combined build + upload
+.PHONY: frontend-deploy
+frontend-deploy: frontend-build frontend-upload
+	@echo "✅ Deployment complete!"
+
+# Clean the build output
+.PHONY: frontend-clean
+frontend-clean:
+	@echo "🧹 Cleaning $(DIST_DIR)..."
+	rm -rf $(DIST_DIR)
+
 # === Docker ===
 .PHONY: docker-up
 docker-up:
@@ -61,17 +81,19 @@ docker-rebuild:
 
 # Frontend ECR build
 build-frontend-prod:
-	docker build -f frontend/Dockerfile.prod -t $(FRONTEND_IMAGE) frontend
+	docker build -f frontend/Dockerfile.prod -t $(FRONTEND_IMAGE):$(VERSION) frontend
 
 # Backend ECR build
 build-backend-prod:
-	docker build -f backend/Dockerfile.prod -t $(BACKEND_IMAGE) backend
+	docker build -f backend/Dockerfile.prod -t $(BACKEND_IMAGE):$(VERSION) backend
 
 push-frontend: build-frontend-prod
-	docker push $(FRONTEND_IMAGE)
+	docker push $(FRONTEND_IMAGE):$(VERSION)
 
 push-backend: build-backend-prod
-	docker push $(BACKEND_IMAGE)
+	docker push $(BACKEND_IMAGE):$(VERSION)
+
+
 
 # === Clean ===
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PYTHON=python3
 VENV_DIR=backend/venv
 BACKEND_DIR=backend
 REQUIREMENTS=$(BACKEND_DIR)/requirements.txt
+FRONTEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend
+BACKEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend
 
 .PHONY: venv
 venv:
@@ -56,6 +58,20 @@ docker-rebuild:
 	docker-compose down -v
 	docker-compose build
 	docker-compose up
+
+# Frontend ECR build
+build-frontend-prod:
+	docker build -f frontend/Dockerfile.prod -t $(FRONTEND_IMAGE) frontend
+
+# Backend ECR build
+build-backend-prod:
+	docker build -f backend/Dockerfile.prod -t $(BACKEND_IMAGE) backend
+
+push-frontend: build-frontend-prod
+	docker push $(FRONTEND_IMAGE)
+
+push-backend: build-backend-prod
+	docker push $(BACKEND_IMAGE)
 
 # === Clean ===
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ PYTHON=python3
 VENV_DIR=backend/venv
 BACKEND_DIR=backend
 REQUIREMENTS=$(BACKEND_DIR)/requirements.txt
-FRONTEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend
-BACKEND_IMAGE=896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend
+FRONTEND_IMAGE=896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-frontend
+BACKEND_IMAGE=896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend
 VERSION=v0.0.2
-BUCKET_NAME=shrubb-ai-stock-analyzer-frontend
+BUCKET_NAME=shrubb-stock-analyzer-frontend
 DIST_DIR=frontend/dist
 
 .PHONY: venv
@@ -79,21 +79,12 @@ docker-rebuild:
 	docker-compose build
 	docker-compose up
 
-# Frontend ECR build
-build-frontend-prod:
-	docker build -f frontend/Dockerfile.prod -t $(FRONTEND_IMAGE):$(VERSION) frontend
-
 # Backend ECR build
 build-backend-prod:
 	docker build -f backend/Dockerfile.prod -t $(BACKEND_IMAGE):$(VERSION) backend
 
-push-frontend: build-frontend-prod
-	docker push $(FRONTEND_IMAGE):$(VERSION)
-
 push-backend: build-backend-prod
 	docker push $(BACKEND_IMAGE):$(VERSION)
-
-
 
 # === Clean ===
 .PHONY: clean

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,12 +10,12 @@ from datetime import datetime
 from functools import lru_cache    # ⚡ Simple in-memory caching
 
 
-app = FastAPI()
+app = FastAPI(root_path="/api")  
 
 # Allow frontend access (adjust for prod)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
   frontend:
     build:
       context: ./frontend
+    environment:
+    - VITE_API_URL=http://localhost:8000
     ports:
       - "5173:5173"
     volumes:

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.stock-analyzer.shrubb.ai

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,5 +6,5 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-EXPOSE 5173
+EXPOSE 80
 CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
+COPY .env.local .env
 RUN npm run build
 
 EXPOSE 80

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,6 +2,7 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 COPY . .
+COPY .env.production .env
 RUN npm install && npm run build
 
 # Serve stage

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -10,4 +10,4 @@ RUN npm install -g http-server
 WORKDIR /app
 COPY --from=builder /app/dist .
 EXPOSE 80
-CMD ["http-server", "-p", "80"]
+CMD ["http-server", "-p", "80", "--spa"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
+# Serve stage
+FROM node:18-alpine
+RUN npm install -g http-server
+WORKDIR /app
+COPY --from=builder /app/dist .
+EXPOSE 80
+CMD ["http-server", "-p", "80"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Stock Analyzer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,4 @@
 .read-the-docs {
   color: #888;
 }
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,10 +15,10 @@ function App() {
     setPredictions([]);
 
     try {
-      const res = await axios.post("http://localhost:8000/predict", { ticker });
+      const res = await axios.post("/api/predict", { ticker });
       setPredictions(res.data.predictions);
     } catch (err) {
-      setError(err.response?.data?.detail || "Prediction failed.");
+      setError(err.response?.data?.detail || "Failed to get Predictions.");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
     setPredictions([]);
 
     try {
-      const res = await axios.post("/api/predict", { ticker });
+      const res = await axios.post(`${import.meta.env.VITE_API_BASE_URL}/predict`, { ticker });
       setPredictions(res.data.predictions);
     } catch (err) {
       setError(err.response?.data?.detail || "Failed to get Predictions.");

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,3 +8,4 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>,
 )
+

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/',
   plugins: [react()],
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,8 +8,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         target: 'http://stock-analyzer-backend:8000',
-        changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, ''),
+        changeOrigin: true
       },
     },
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,14 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/',
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://stock-analyzer-backend:8000',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.99.1"
+  hashes = [
+    "h1:967WCGUW/vgrjUMBvC+HCie1DVgOXHwUkhm2ng3twJw=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/terraform/ecs/iam.tf
+++ b/terraform/ecs/iam.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "ecsTaskExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution_policy" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/terraform/ecs/main.tf
+++ b/terraform/ecs/main.tf
@@ -1,0 +1,34 @@
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = "stock-analyzer-cluster"
+}
+
+# Security group for ECS tasks
+resource "aws_security_group" "ecs_tasks" {
+  name        = "ecs-tasks-sg"
+  description = "Allow traffic from ALB to ECS tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # ALB security group will refine this later
+  }
+
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "ecs-tasks-sg" }
+}

--- a/terraform/ecs/outputs.tf
+++ b/terraform/ecs/outputs.tf
@@ -6,10 +6,6 @@ output "ecs_tasks_sg_id" {
   value = aws_security_group.ecs_tasks.id
 }
 
-output "frontend_service_name" {
-  value = aws_ecs_service.frontend.name
-}
-
 output "backend_service_name" {
   value = aws_ecs_service.backend.name
 }

--- a/terraform/ecs/outputs.tf
+++ b/terraform/ecs/outputs.tf
@@ -1,0 +1,15 @@
+output "ecs_cluster_id" {
+  value = aws_ecs_cluster.main.id
+}
+
+output "ecs_tasks_sg_id" {
+  value = aws_security_group.ecs_tasks.id
+}
+
+output "frontend_service_name" {
+  value = aws_ecs_service.frontend.name
+}
+
+output "backend_service_name" {
+  value = aws_ecs_service.backend.name
+}

--- a/terraform/ecs/tasks.tf
+++ b/terraform/ecs/tasks.tf
@@ -1,0 +1,72 @@
+# Frontend Task
+resource "aws_ecs_task_definition" "frontend" {
+  family                   = "frontend-task"
+  network_mode            = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                     = "256"
+  memory                  = "512"
+  execution_role_arn      = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([{
+    name      = "frontend"
+    image     = var.frontend_image
+    portMappings = [{ containerPort = 80 }]
+    essential = true
+  }])
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "backend-task"
+  network_mode            = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                     = "256"
+  memory                  = "512"
+  execution_role_arn      = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([{
+    name      = "backend"
+    image     = var.backend_image
+    portMappings = [{ containerPort = 8000 }]
+    essential = true
+  }])
+}
+
+resource "aws_ecs_service" "frontend" {
+  name            = "frontend-service"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.frontend.arn
+  launch_type     = "FARGATE"
+  desired_count   = 1
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = [var.ecs_tasks_sg_id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = var.frontend_tg_arn
+    container_name   = "frontend"
+    container_port   = 80
+  }
+}
+
+resource "aws_ecs_service" "backend" {
+  name            = "backend-service"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.backend.arn
+  launch_type     = "FARGATE"
+  desired_count   = 1
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = [var.ecs_tasks_sg_id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = var.backend_tg_arn
+    container_name   = "backend"
+    container_port   = 8000
+  }
+}

--- a/terraform/ecs/tasks.tf
+++ b/terraform/ecs/tasks.tf
@@ -1,20 +1,3 @@
-# Frontend Task
-resource "aws_ecs_task_definition" "frontend" {
-  family                   = "frontend-task"
-  network_mode            = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
-  cpu                     = "256"
-  memory                  = "512"
-  execution_role_arn      = aws_iam_role.ecs_task_execution.arn
-
-  container_definitions = jsonencode([{
-    name      = "frontend"
-    image     = var.frontend_image
-    portMappings = [{ containerPort = 80 }]
-    essential = true
-  }])
-}
-
 resource "aws_ecs_task_definition" "backend" {
   family                   = "backend-task"
   network_mode            = "awsvpc"
@@ -29,26 +12,6 @@ resource "aws_ecs_task_definition" "backend" {
     portMappings = [{ containerPort = 8000 }]
     essential = true
   }])
-}
-
-resource "aws_ecs_service" "frontend" {
-  name            = "frontend-service"
-  cluster         = var.ecs_cluster_id
-  task_definition = aws_ecs_task_definition.frontend.arn
-  launch_type     = "FARGATE"
-  desired_count   = 1
-
-  network_configuration {
-    subnets         = var.subnets
-    security_groups = [var.ecs_tasks_sg_id]
-    assign_public_ip = true
-  }
-
-  load_balancer {
-    target_group_arn = var.frontend_tg_arn
-    container_name   = "frontend"
-    container_port   = 80
-  }
 }
 
 resource "aws_ecs_service" "backend" {

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {}
+variable "public_subnets" {
+  type = list(string)
+}
+
+variable "frontend_image" {}
+variable "backend_image" {}
+variable "subnets" {
+  type = list(string)
+}
+variable "ecs_tasks_sg_id" {}
+variable "frontend_tg_arn" {}
+variable "backend_tg_arn" {}
+variable "ecs_cluster_id" {}

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -3,12 +3,10 @@ variable "public_subnets" {
   type = list(string)
 }
 
-variable "frontend_image" {}
 variable "backend_image" {}
 variable "subnets" {
   type = list(string)
 }
 variable "ecs_tasks_sg_id" {}
-variable "frontend_tg_arn" {}
 variable "backend_tg_arn" {}
 variable "ecs_cluster_id" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,10 +18,19 @@ module "ecs" {
   public_subnets     = module.network.public_subnets
   ecs_cluster_id     = module.ecs.ecs_cluster_id
   ecs_tasks_sg_id    = module.ecs.ecs_tasks_sg_id
-  frontend_image     = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest"
-  backend_image      = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest"
-  frontend_tg_arn    = module.network.frontend_tg_arn
+  backend_image      = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2"
   backend_tg_arn     = module.network.backend_tg_arn
   subnets            = module.network.public_subnets
+}
+
+module "s3cloudfront" {
+  source      = "./s3cloudfront"
+  region      = "us-east-2"
+  bucket_name = "shrubb-ai-stock-analyzer-frontend"
+  acm_certificate_arn = module.network.frontend_acm_cert_arn
+  tags = {
+    Project = "StockAnalyzer"
+    Env     = "prod"
+  }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-east-2" # Main region for ECS, ALB, VPC
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1" # Required only for ACM certs
+}
+
+module "network" {
+  source = "./network"
+}
+
+module "ecs" {
+  source = "./ecs"
+
+  vpc_id             = module.network.vpc_id
+  public_subnets     = module.network.public_subnets
+  ecs_cluster_id     = module.ecs.ecs_cluster_id
+  ecs_tasks_sg_id    = module.ecs.ecs_tasks_sg_id
+  frontend_image     = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest"
+  backend_image      = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest"
+  frontend_tg_arn    = module.network.frontend_tg_arn
+  backend_tg_arn     = module.network.backend_tg_arn
+  subnets            = module.network.public_subnets
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,5 @@
 provider "aws" {
-  region = "us-east-2" # Main region for ECS, ALB, VPC
-}
-
-provider "aws" {
-  alias  = "us_east_1"
-  region = "us-east-1" # Required only for ACM certs
+  region = "us-east-1" # Main region for ECS, ALB, VPC
 }
 
 module "network" {
@@ -18,15 +13,14 @@ module "ecs" {
   public_subnets     = module.network.public_subnets
   ecs_cluster_id     = module.ecs.ecs_cluster_id
   ecs_tasks_sg_id    = module.ecs.ecs_tasks_sg_id
-  backend_image      = "896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2"
+  backend_image      = "896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend:v0.0.2"
   backend_tg_arn     = module.network.backend_tg_arn
   subnets            = module.network.public_subnets
 }
 
 module "s3cloudfront" {
   source      = "./s3cloudfront"
-  region      = "us-east-2"
-  bucket_name = "shrubb-ai-stock-analyzer-frontend"
+  bucket_name = "shrubb-stock-analyzer-frontend"
   acm_certificate_arn = module.network.frontend_acm_cert_arn
   tags = {
     Project = "StockAnalyzer"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,7 +21,7 @@ module "ecs" {
 module "s3cloudfront" {
   source      = "./s3cloudfront"
   bucket_name = "shrubb-stock-analyzer-frontend"
-  acm_certificate_arn = module.network.frontend_acm_cert_arn
+  acm_certificate_arn = module.network.frontend_cert_arn
   tags = {
     Project = "StockAnalyzer"
     Env     = "prod"

--- a/terraform/network/acm.tf
+++ b/terraform/network/acm.tf
@@ -1,7 +1,14 @@
-resource "aws_acm_certificate" "cert" {
+resource "aws_acm_certificate" "frontend_cert" {
   domain_name       = "stock-analyzer.shrubb.ai"
   validation_method = "DNS"
   tags = {
-    Name = "stock-analyzer-cert"
+    Name = "stock-analyzer-frontend-cert"
+  }
+}
+resource "aws_acm_certificate" "backend_cert" {
+  domain_name       = "api.stock-analyzer.shrubb.ai"
+  validation_method = "DNS"
+  tags = {
+    Name = "stock-analyzer-backend-cert"
   }
 }

--- a/terraform/network/acm.tf
+++ b/terraform/network/acm.tf
@@ -1,0 +1,8 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "stock-analyzer.shrubb.ai"
+  validation_method = "DNS"
+
+  tags = {
+    Name = "stock-analyzer-cert"
+  }
+}

--- a/terraform/network/acm.tf
+++ b/terraform/network/acm.tf
@@ -1,6 +1,7 @@
 resource "aws_acm_certificate" "cert" {
   domain_name       = "stock-analyzer.shrubb.ai"
   validation_method = "DNS"
+  provider = aws.us_east_1
 
   tags = {
     Name = "stock-analyzer-cert"

--- a/terraform/network/acm.tf
+++ b/terraform/network/acm.tf
@@ -1,8 +1,6 @@
 resource "aws_acm_certificate" "cert" {
   domain_name       = "stock-analyzer.shrubb.ai"
   validation_method = "DNS"
-  provider = aws.us_east_1
-
   tags = {
     Name = "stock-analyzer-cert"
   }

--- a/terraform/network/main.tf
+++ b/terraform/network/main.tf
@@ -96,26 +96,22 @@ resource "aws_lb_target_group" "backend" {
 }
 
 # HTTPS Listener
-resource "aws_lb_listener" "https" {
+resource "aws_lb_listener" "https_backend" {
   load_balancer_arn = aws_lb.main.arn
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = aws_acm_certificate.cert.arn
+  certificate_arn   = aws_acm_certificate.backend_cert.arn
 
   default_action {
-    type             = "fixed-response"
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Not found"
-      status_code  = "404"
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
   }
 }
 
-resource "aws_lb_listener_rule" "api_routing" {
-  listener_arn = aws_lb_listener.https.arn
-  priority     = 20
+resource "aws_lb_listener_rule" "api_host_routing" {
+  listener_arn = aws_lb_listener.https_backend.arn
+  priority     = 10
 
   action {
     type             = "forward"
@@ -123,9 +119,8 @@ resource "aws_lb_listener_rule" "api_routing" {
   }
 
   condition {
-    path_pattern {
-      values = ["/api/*"]
+    host_header {
+      values = ["api.stockanalyzer.shrubb.ai"]
     }
   }
 }
-

--- a/terraform/network/main.tf
+++ b/terraform/network/main.tf
@@ -1,0 +1,174 @@
+variable "region" {
+  default = "us-east-2"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags = { Name = "stock-vpc" }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 4, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags = { Name = "stock-public-${count.index}" }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route" "internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ALB Security Group
+resource "aws_security_group" "alb" {
+  name        = "alb-sg"
+  description = "Allow HTTP/HTTPS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "alb-sg" }
+}
+
+# Application Load Balancer
+resource "aws_lb" "main" {
+  name               = "stock-analyzer-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+
+  tags = { Name = "stock-analyzer-alb" }
+}
+
+# Frontend Target Group
+resource "aws_lb_target_group" "frontend" {
+  name        = "frontend-tg"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}
+
+# Backend Target Group
+resource "aws_lb_target_group" "backend" {
+  name        = "backend-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/predict"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}
+
+# HTTP Listener (or HTTPS if using TLS)
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Default backend reached"
+      status_code  = "404"
+    }
+  }
+}
+
+# Listener Rule for Frontend
+resource "aws_lb_listener_rule" "frontend" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.frontend.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/"]
+    }
+  }
+}
+
+# Listener Rule for Backend (optional if exposed publicly)
+resource "aws_lb_listener_rule" "backend" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 101
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/predict"]
+    }
+  }
+}
+
+

--- a/terraform/network/outputs.tf
+++ b/terraform/network/outputs.tf
@@ -11,9 +11,14 @@ output "backend_tg_arn" {
 }
 
 output "alb_listener_arn" {
-  value = aws_lb_listener.https.arn
+  value = aws_lb_listener.https_backend.arn
 }
 
-output "frontend_acm_cert_arn" {
-  value = aws_acm_certificate.cert.arn
+# Output these ARNs for use in other modules
+output "frontend_cert_arn" {
+  value = aws_acm_certificate.frontend_cert.arn
+}
+
+output "backend_cert_arn" {
+  value = aws_acm_certificate.backend_cert.arn
 }

--- a/terraform/network/outputs.tf
+++ b/terraform/network/outputs.tf
@@ -11,7 +11,7 @@ output "backend_tg_arn" {
 }
 
 output "alb_listener_arn" {
-  value = aws_lb_listener.http.arn
+  value = aws_lb_listener.https.arn
 }
 
 output "frontend_acm_cert_arn" {

--- a/terraform/network/outputs.tf
+++ b/terraform/network/outputs.tf
@@ -6,14 +6,14 @@ output "public_subnets" {
   value = aws_subnet.public[*].id
 }
 
-output "frontend_tg_arn" {
-  value = aws_lb_target_group.frontend.arn
-}
-
 output "backend_tg_arn" {
   value = aws_lb_target_group.backend.arn
 }
 
 output "alb_listener_arn" {
   value = aws_lb_listener.http.arn
+}
+
+output "frontend_acm_cert_arn" {
+  value = aws_acm_certificate.cert.arn
 }

--- a/terraform/network/outputs.tf
+++ b/terraform/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnets" {
+  value = aws_subnet.public[*].id
+}
+
+output "frontend_tg_arn" {
+  value = aws_lb_target_group.frontend.arn
+}
+
+output "backend_tg_arn" {
+  value = aws_lb_target_group.backend.arn
+}
+
+output "alb_listener_arn" {
+  value = aws_lb_listener.http.arn
+}

--- a/terraform/s3cloudfront/main.tf
+++ b/terraform/s3cloudfront/main.tf
@@ -1,9 +1,4 @@
 # frontend/main.tf
-
-provider "aws" {
-  region = var.region
-}
-
 resource "aws_s3_bucket" "frontend" {
   bucket = var.bucket_name
   force_destroy = true

--- a/terraform/s3cloudfront/main.tf
+++ b/terraform/s3cloudfront/main.tf
@@ -1,0 +1,116 @@
+# frontend/main.tf
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.bucket_name
+  force_destroy = true
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "frontend-oac"
+  description                       = "OAC for S3 frontend"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  origin {
+    domain_name = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id   = "frontend-origin"
+
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases = ["stock-analyzer.shrubb.ai"]
+
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "frontend-origin"
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = var.acm_certificate_arn
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.2_2021"
+  }
+
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.frontend.arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      }
+    ]
+  })
+}
+

--- a/terraform/s3cloudfront/variables.tf
+++ b/terraform/s3cloudfront/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  description = "AWS region to deploy resources in"
-  type        = string
-}
-
 variable "bucket_name" {
   description = "Name of the S3 bucket to host the frontend"
   type        = string

--- a/terraform/s3cloudfront/variables.tf
+++ b/terraform/s3cloudfront/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  description = "AWS region to deploy resources in"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket to host the frontend"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for CloudFront"
+  type        = string
+}
+
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,8 +1,8 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 74,
-  "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
+  "serial": 45,
+  "lineage": "502feed0-8c80-a89e-54b6-eae94b4ea6d0",
   "outputs": {},
   "resources": [
     {
@@ -15,9 +15,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "arn": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "configuration": [],
-            "id": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "id": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "name": "stock-analyzer-cluster",
             "service_connect_defaults": [],
             "setting": [
@@ -48,7 +48,7 @@
             "alarms": [],
             "availability_zone_rebalancing": "DISABLED",
             "capacity_provider_strategy": [],
-            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "cluster": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "deployment_circuit_breaker": [
               {
                 "enable": false,
@@ -69,14 +69,14 @@
             "force_new_deployment": null,
             "health_check_grace_period_seconds": 0,
             "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
-            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/backend-service",
+            "id": "arn:aws:ecs:us-east-1:896924684176:service/stock-analyzer-cluster/backend-service",
             "launch_type": "FARGATE",
             "load_balancer": [
               {
                 "container_name": "backend",
                 "container_port": 8000,
                 "elb_name": "",
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db"
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6"
               }
             ],
             "name": "backend-service",
@@ -84,11 +84,11 @@
               {
                 "assign_public_ip": true,
                 "security_groups": [
-                  "sg-042b54e04d09d4588"
+                  "sg-0aee182cece4a11e9"
                 ],
                 "subnets": [
-                  "subnet-0a2b4b43925401a30",
-                  "subnet-0c3b58546b6dff7dd"
+                  "subnet-0043925f401046cda",
+                  "subnet-0f100907225ebc945"
                 ]
               }
             ],
@@ -101,7 +101,7 @@
             "service_registries": [],
             "tags": {},
             "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
+            "task_definition": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:2",
             "timeouts": null,
             "triggers": {},
             "volume_configuration": [],
@@ -134,9 +134,9 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
-            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "arn": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:2",
+            "arn_without_revision": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
             "cpu": "256",
             "enable_fault_injection": false,
             "ephemeral_storage": [],
@@ -153,10 +153,10 @@
             "requires_compatibilities": [
               "FARGATE"
             ],
-            "revision": 3,
+            "revision": 2,
             "runtime_platform": [],
             "skip_destroy": false,
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "task_role_arn": "",
             "track_latest": false,
@@ -183,7 +183,7 @@
           "attributes": {
             "arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
             "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
-            "create_date": "2025-06-12T16:45:38Z",
+            "create_date": "2025-06-16T16:04:43Z",
             "description": "",
             "force_detach_policies": false,
             "id": "ecsTaskExecutionRole",
@@ -198,7 +198,7 @@
             "permissions_boundary": "",
             "tags": {},
             "tags_all": {},
-            "unique_id": "AROA5BVHAR6IEKMAKZELH"
+            "unique_id": "AROA5BVHAR6IPGSL6T44V"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -216,7 +216,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "ecsTaskExecutionRole-20250612164537129100000001",
+            "id": "ecsTaskExecutionRole-20250616160442567800000002",
             "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
             "role": "ecsTaskExecutionRole"
           },
@@ -239,7 +239,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-042b54e04d09d4588",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:security-group/sg-0aee182cece4a11e9",
             "description": "Allow traffic from ALB to ECS tasks",
             "egress": [
               {
@@ -256,7 +256,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-042b54e04d09d4588",
+            "id": "sg-0aee182cece4a11e9",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -296,7 +296,7 @@
               "Name": "ecs-tasks-sg"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -312,7 +312,7 @@
       "mode": "data",
       "type": "aws_availability_zones",
       "name": "available",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -322,20 +322,26 @@
             "exclude_zone_ids": null,
             "filter": null,
             "group_names": [
-              "us-east-2-zg-1"
+              "us-east-1-zg-1"
             ],
-            "id": "us-east-2",
+            "id": "us-east-1",
             "names": [
-              "us-east-2a",
-              "us-east-2b",
-              "us-east-2c"
+              "us-east-1a",
+              "us-east-1b",
+              "us-east-1c",
+              "us-east-1d",
+              "us-east-1e",
+              "us-east-1f"
             ],
             "state": null,
             "timeouts": null,
             "zone_ids": [
-              "use2-az1",
-              "use2-az2",
-              "use2-az3"
+              "use1-az4",
+              "use1-az6",
+              "use1-az1",
+              "use1-az2",
+              "use1-az3",
+              "use1-az5"
             ]
           },
           "sensitive_attributes": [],
@@ -348,12 +354,12 @@
       "mode": "managed",
       "type": "aws_acm_certificate",
       "name": "cert",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"].us_east_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "certificate_authority_arn": "",
             "certificate_body": null,
             "certificate_chain": null,
@@ -367,10 +373,10 @@
               }
             ],
             "early_renewal_duration": "",
-            "id": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "key_algorithm": "RSA_2048",
-            "not_after": "2026-07-12T23:59:59Z",
-            "not_before": "2025-06-13T00:00:00Z",
+            "not_after": "2026-07-15T23:59:59Z",
+            "not_before": "2025-06-16T00:00:00Z",
             "options": [
               {
                 "certificate_transparency_logging_preference": "ENABLED"
@@ -413,18 +419,18 @@
       "mode": "managed",
       "type": "aws_internet_gateway",
       "name": "gw",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:internet-gateway/igw-0fa0bc93b789a7643",
-            "id": "igw-0fa0bc93b789a7643",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:internet-gateway/igw-0d11b3068dad9d031",
+            "id": "igw-0d11b3068dad9d031",
             "owner_id": "896924684176",
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -440,7 +446,7 @@
       "mode": "managed",
       "type": "aws_lb",
       "name": "main",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -452,8 +458,8 @@
                 "prefix": ""
               }
             ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
-            "arn_suffix": "app/stock-analyzer-alb/f81c590316270958",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
+            "arn_suffix": "app/stock-analyzer-alb/b093953306bc1430",
             "client_keep_alive": 3600,
             "connection_logs": [
               {
@@ -464,7 +470,7 @@
             ],
             "customer_owned_ipv4_pool": "",
             "desync_mitigation_mode": "defensive",
-            "dns_name": "stock-analyzer-alb-1551012673.us-east-2.elb.amazonaws.com",
+            "dns_name": "stock-analyzer-alb-1625738139.us-east-1.elb.amazonaws.com",
             "dns_record_client_routing_policy": null,
             "drop_invalid_header_fields": false,
             "enable_cross_zone_load_balancing": true,
@@ -475,7 +481,7 @@
             "enable_xff_client_port": false,
             "enable_zonal_shift": false,
             "enforce_security_group_inbound_rules_on_private_link_traffic": "",
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
             "idle_timeout": 60,
             "internal": false,
             "ip_address_type": "ipv4",
@@ -486,7 +492,7 @@
             "name_prefix": "",
             "preserve_host_header": false,
             "security_groups": [
-              "sg-0849043bdcac304cd"
+              "sg-0e35606b1c6fb04c3"
             ],
             "subnet_mapping": [
               {
@@ -494,19 +500,19 @@
                 "ipv6_address": "",
                 "outpost_id": "",
                 "private_ipv4_address": "",
-                "subnet_id": "subnet-0a2b4b43925401a30"
+                "subnet_id": "subnet-0043925f401046cda"
               },
               {
                 "allocation_id": "",
                 "ipv6_address": "",
                 "outpost_id": "",
                 "private_ipv4_address": "",
-                "subnet_id": "subnet-0c3b58546b6dff7dd"
+                "subnet_id": "subnet-0f100907225ebc945"
               }
             ],
             "subnets": [
-              "subnet-0a2b4b43925401a30",
-              "subnet-0c3b58546b6dff7dd"
+              "subnet-0043925f401046cda",
+              "subnet-0f100907225ebc945"
             ],
             "tags": {
               "Name": "stock-analyzer-alb"
@@ -515,9 +521,9 @@
               "Name": "stock-analyzer-alb"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a",
+            "vpc_id": "vpc-0997b90c9d647d6e2",
             "xff_header_processing_mode": "append",
-            "zone_id": "Z3AADJGX6KTTL2"
+            "zone_id": "Z35SXDOTRQ7X7K"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -535,15 +541,15 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_lb_listener",
-      "name": "http",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "name": "https",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "alpn_policy": null,
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "certificate_arn": null,
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "default_action": [
               {
                 "authenticate_cognito": [],
@@ -551,7 +557,7 @@
                 "fixed_response": [
                   {
                     "content_type": "text/plain",
-                    "message_body": "Default backend reached",
+                    "message_body": "Not found",
                     "status_code": "404"
                   }
                 ],
@@ -562,19 +568,26 @@
                 "type": "fixed-response"
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
-            "mutual_authentication": [],
-            "port": 80,
-            "protocol": "HTTP",
-            "routing_http_request_x_amzn_mtls_clientcert_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": null,
-            "routing_http_request_x_amzn_tls_cipher_suite_header_name": null,
-            "routing_http_request_x_amzn_tls_version_header_name": null,
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
+            "mutual_authentication": [
+              {
+                "advertise_trust_store_ca_names": "",
+                "ignore_client_certificate_expiry": false,
+                "mode": "off",
+                "trust_store_arn": ""
+              }
+            ],
+            "port": 443,
+            "protocol": "HTTPS",
+            "routing_http_request_x_amzn_mtls_clientcert_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": "",
+            "routing_http_request_x_amzn_tls_cipher_suite_header_name": "",
+            "routing_http_request_x_amzn_tls_version_header_name": "",
             "routing_http_response_access_control_allow_credentials_header_value": "",
             "routing_http_response_access_control_allow_headers_header_value": "",
             "routing_http_response_access_control_allow_methods_header_value": "",
@@ -586,7 +599,7 @@
             "routing_http_response_strict_transport_security_header_value": "",
             "routing_http_response_x_content_type_options_header_value": "",
             "routing_http_response_x_frame_options_header_value": "",
-            "ssl_policy": "",
+            "ssl_policy": "ELBSecurityPolicy-2016-08",
             "tags": {},
             "tags_all": {},
             "tcp_idle_timeout_seconds": null,
@@ -596,7 +609,69 @@
           "identity_schema_version": 0,
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
           "dependencies": [
+            "module.network.aws_acm_certificate.cert",
             "module.network.aws_lb.main",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "api_routing",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/api/*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "priority": 20,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.https",
+            "module.network.aws_lb_target_group.backend",
             "module.network.aws_security_group.alb",
             "module.network.aws_subnet.public",
             "module.network.aws_vpc.main",
@@ -610,13 +685,13 @@
       "mode": "managed",
       "type": "aws_lb_target_group",
       "name": "backend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
-            "arn_suffix": "targetgroup/backend-tg/4bb7268be23e80db",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
+            "arn_suffix": "targetgroup/backend-tg/1056eddac5e222d6",
             "connection_termination": null,
             "deregistration_delay": "300",
             "health_check": [
@@ -632,10 +707,12 @@
                 "unhealthy_threshold": 2
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
             "ip_address_type": "ipv4",
             "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [],
+            "load_balancer_arns": [
+              "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430"
+            ],
             "load_balancing_algorithm_type": "round_robin",
             "load_balancing_anomaly_mitigation": "off",
             "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
@@ -686,7 +763,7 @@
               }
             ],
             "target_type": "ip",
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -702,7 +779,7 @@
       "mode": "managed",
       "type": "aws_route",
       "name": "internet_access",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -713,15 +790,15 @@
             "destination_ipv6_cidr_block": "",
             "destination_prefix_list_id": "",
             "egress_only_gateway_id": "",
-            "gateway_id": "igw-0fa0bc93b789a7643",
-            "id": "r-rtb-0c3bad089d9c13adc1080289494",
+            "gateway_id": "igw-0d11b3068dad9d031",
+            "id": "r-rtb-034d9c8732eb26e0f1080289494",
             "instance_id": "",
             "instance_owner_id": "",
             "local_gateway_id": "",
             "nat_gateway_id": "",
             "network_interface_id": "",
             "origin": "CreateRoute",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
             "state": "active",
             "timeouts": null,
             "transit_gateway_id": "",
@@ -744,13 +821,13 @@
       "mode": "managed",
       "type": "aws_route_table",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:route-table/rtb-0c3bad089d9c13adc",
-            "id": "rtb-0c3bad089d9c13adc",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:route-table/rtb-034d9c8732eb26e0f",
+            "id": "rtb-034d9c8732eb26e0f",
             "owner_id": "896924684176",
             "propagating_vgws": [],
             "route": [
@@ -760,7 +837,7 @@
                 "core_network_arn": "",
                 "destination_prefix_list_id": "",
                 "egress_only_gateway_id": "",
-                "gateway_id": "igw-0fa0bc93b789a7643",
+                "gateway_id": "igw-0d11b3068dad9d031",
                 "ipv6_cidr_block": "",
                 "local_gateway_id": "",
                 "nat_gateway_id": "",
@@ -773,7 +850,7 @@
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -789,16 +866,16 @@
       "mode": "managed",
       "type": "aws_route_table_association",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "index_key": 0,
           "schema_version": 0,
           "attributes": {
             "gateway_id": "",
-            "id": "rtbassoc-0644356cbf9fcd16a",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
-            "subnet_id": "subnet-0a2b4b43925401a30",
+            "id": "rtbassoc-0a6019f8929054f92",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
+            "subnet_id": "subnet-0043925f401046cda",
             "timeouts": null
           },
           "sensitive_attributes": [],
@@ -816,9 +893,9 @@
           "schema_version": 0,
           "attributes": {
             "gateway_id": "",
-            "id": "rtbassoc-061959307ae8430b0",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
-            "subnet_id": "subnet-0c3b58546b6dff7dd",
+            "id": "rtbassoc-0eea9c0ead828fbb8",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
+            "subnet_id": "subnet-0f100907225ebc945",
             "timeouts": null
           },
           "sensitive_attributes": [],
@@ -838,12 +915,12 @@
       "mode": "managed",
       "type": "aws_security_group",
       "name": "alb",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-0849043bdcac304cd",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:security-group/sg-0e35606b1c6fb04c3",
             "description": "Allow HTTP/HTTPS inbound traffic",
             "egress": [
               {
@@ -860,7 +937,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-0849043bdcac304cd",
+            "id": "sg-0e35606b1c6fb04c3",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -900,7 +977,7 @@
               "Name": "alb-sg"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -916,23 +993,23 @@
       "mode": "managed",
       "type": "aws_subnet",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "index_key": 0,
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0a2b4b43925401a30",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:subnet/subnet-0043925f401046cda",
             "assign_ipv6_address_on_creation": false,
-            "availability_zone": "us-east-2a",
-            "availability_zone_id": "use2-az1",
+            "availability_zone": "us-east-1a",
+            "availability_zone_id": "use1-az4",
             "cidr_block": "10.0.0.0/20",
             "customer_owned_ipv4_pool": "",
             "enable_dns64": false,
             "enable_lni_at_device_index": 0,
             "enable_resource_name_dns_a_record_on_launch": false,
             "enable_resource_name_dns_aaaa_record_on_launch": false,
-            "id": "subnet-0a2b4b43925401a30",
+            "id": "subnet-0043925f401046cda",
             "ipv6_cidr_block": "",
             "ipv6_cidr_block_association_id": "",
             "ipv6_native": false,
@@ -948,7 +1025,7 @@
               "Name": "stock-public-0"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -962,17 +1039,17 @@
           "index_key": 1,
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0c3b58546b6dff7dd",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:subnet/subnet-0f100907225ebc945",
             "assign_ipv6_address_on_creation": false,
-            "availability_zone": "us-east-2b",
-            "availability_zone_id": "use2-az2",
+            "availability_zone": "us-east-1b",
+            "availability_zone_id": "use1-az6",
             "cidr_block": "10.0.16.0/20",
             "customer_owned_ipv4_pool": "",
             "enable_dns64": false,
             "enable_lni_at_device_index": 0,
             "enable_resource_name_dns_a_record_on_launch": false,
             "enable_resource_name_dns_aaaa_record_on_launch": false,
-            "id": "subnet-0c3b58546b6dff7dd",
+            "id": "subnet-0f100907225ebc945",
             "ipv6_cidr_block": "",
             "ipv6_cidr_block_association_id": "",
             "ipv6_native": false,
@@ -988,7 +1065,7 @@
               "Name": "stock-public-1"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1005,22 +1082,22 @@
       "mode": "managed",
       "type": "aws_vpc",
       "name": "main",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:vpc/vpc-0e677828b4dc5fa9a",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:vpc/vpc-0997b90c9d647d6e2",
             "assign_generated_ipv6_cidr_block": false,
             "cidr_block": "10.0.0.0/16",
-            "default_network_acl_id": "acl-0686f8d4be1e2c8dc",
-            "default_route_table_id": "rtb-0509e12dac3222b5d",
-            "default_security_group_id": "sg-010ecb86c454dda99",
-            "dhcp_options_id": "dopt-08834e4367484cb08",
+            "default_network_acl_id": "acl-0a373b2c9d432f23a",
+            "default_route_table_id": "rtb-028eb59674d07acfc",
+            "default_security_group_id": "sg-0e7df595b1881bc74",
+            "dhcp_options_id": "dopt-0b60817d35a8d54da",
             "enable_dns_hostnames": true,
             "enable_dns_support": true,
             "enable_network_address_usage_metrics": false,
-            "id": "vpc-0e677828b4dc5fa9a",
+            "id": "vpc-0997b90c9d647d6e2",
             "instance_tenancy": "default",
             "ipv4_ipam_pool_id": null,
             "ipv4_netmask_length": null,
@@ -1029,7 +1106,7 @@
             "ipv6_cidr_block_network_border_group": "",
             "ipv6_ipam_pool_id": "",
             "ipv6_netmask_length": 0,
-            "main_route_table_id": "rtb-0509e12dac3222b5d",
+            "main_route_table_id": "rtb-028eb59674d07acfc",
             "owner_id": "896924684176",
             "tags": {
               "Name": "stock-vpc"
@@ -1049,7 +1126,7 @@
       "mode": "managed",
       "type": "aws_cloudfront_distribution",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
@@ -1057,8 +1134,8 @@
             "aliases": [
               "stock-analyzer.shrubb.ai"
             ],
-            "arn": "arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0",
-            "caller_reference": "terraform-20250613165906122800000001",
+            "arn": "arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33",
+            "caller_reference": "terraform-20250616164118108800000001",
             "comment": null,
             "continuous_deployment_policy_id": "",
             "custom_error_response": [
@@ -1116,15 +1193,15 @@
               }
             ],
             "default_root_object": "index.html",
-            "domain_name": "d2g86i0wrkfe7n.cloudfront.net",
+            "domain_name": "dxoccp6gw8qk3.cloudfront.net",
             "enabled": true,
-            "etag": "EQAP9R7SKEFU4",
+            "etag": "E1N0T1754BGVZW",
             "hosted_zone_id": "Z2FDTNDATAQYW2",
             "http_version": "http2",
-            "id": "E14Q29W1T4EPG0",
+            "id": "E3R6TRBTP0FQ33",
             "in_progress_validation_batches": 0,
             "is_ipv6_enabled": true,
-            "last_modified_time": "2025-06-13 17:34:15.562 +0000 UTC",
+            "last_modified_time": "2025-06-16 16:41:19.633 +0000 UTC",
             "logging_config": [],
             "ordered_cache_behavior": [],
             "origin": [
@@ -1133,8 +1210,8 @@
                 "connection_timeout": 10,
                 "custom_header": [],
                 "custom_origin_config": [],
-                "domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
-                "origin_access_control_id": "EF0CVC5NFHZ5L",
+                "domain_name": "shrubb-stock-analyzer-frontend.s3.us-east-1.amazonaws.com",
+                "origin_access_control_id": "E2RNKCR1QR7DXH",
                 "origin_id": "frontend-origin",
                 "origin_path": "",
                 "origin_shield": [],
@@ -1179,7 +1256,7 @@
             ],
             "viewer_certificate": [
               {
-                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
                 "cloudfront_default_certificate": false,
                 "iam_certificate_id": "",
                 "minimum_protocol_version": "TLSv1.2_2021",
@@ -1205,15 +1282,15 @@
       "mode": "managed",
       "type": "aws_cloudfront_origin_access_control",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/EF0CVC5NFHZ5L",
+            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/E2RNKCR1QR7DXH",
             "description": "OAC for S3 frontend",
             "etag": "ETVPDKIKX0DER",
-            "id": "EF0CVC5NFHZ5L",
+            "id": "E2RNKCR1QR7DXH",
             "name": "frontend-oac",
             "origin_access_control_origin_type": "s3",
             "signing_behavior": "always",
@@ -1230,18 +1307,18 @@
       "mode": "managed",
       "type": "aws_s3_bucket",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "acceleration_status": "",
             "acl": null,
-            "arn": "arn:aws:s3:::shrubb-ai-stock-analyzer-frontend",
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
-            "bucket_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.amazonaws.com",
+            "arn": "arn:aws:s3:::shrubb-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "bucket_domain_name": "shrubb-stock-analyzer-frontend.s3.amazonaws.com",
             "bucket_prefix": "",
-            "bucket_regional_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+            "bucket_regional_domain_name": "shrubb-stock-analyzer-frontend.s3.us-east-1.amazonaws.com",
             "cors_rule": [],
             "force_destroy": true,
             "grant": [
@@ -1254,14 +1331,14 @@
                 "uri": ""
               }
             ],
-            "hosted_zone_id": "Z2O1EMRO9K5GLX",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "shrubb-stock-analyzer-frontend",
             "lifecycle_rule": [],
             "logging": [],
             "object_lock_configuration": [],
             "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-east-2",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}",
+            "region": "us-east-1",
             "replication_configuration": [],
             "request_payer": "BucketOwner",
             "server_side_encryption_configuration": [
@@ -1302,8 +1379,8 @@
                 "routing_rules": ""
               }
             ],
-            "website_domain": "s3-website.us-east-2.amazonaws.com",
-            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+            "website_domain": "s3-website-us-east-1.amazonaws.com",
+            "website_endpoint": "shrubb-stock-analyzer-frontend.s3-website-us-east-1.amazonaws.com"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1316,14 +1393,14 @@
       "mode": "managed",
       "type": "aws_s3_bucket_policy",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
-            "id": "shrubb-ai-stock-analyzer-frontend",
-            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-ai-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}"
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1342,15 +1419,15 @@
       "mode": "managed",
       "type": "aws_s3_bucket_public_access_block",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "block_public_acls": true,
             "block_public_policy": true,
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
             "ignore_public_acls": true,
             "restrict_public_buckets": true
           },
@@ -1368,19 +1445,19 @@
       "mode": "managed",
       "type": "aws_s3_bucket_website_configuration",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
             "error_document": [
               {
                 "key": "index.html"
               }
             ],
             "expected_bucket_owner": "",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
             "index_document": [
               {
                 "suffix": "index.html"
@@ -1389,8 +1466,8 @@
             "redirect_all_requests_to": [],
             "routing_rule": [],
             "routing_rules": "",
-            "website_domain": "s3-website.us-east-2.amazonaws.com",
-            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+            "website_domain": "s3-website-us-east-1.amazonaws.com",
+            "website_endpoint": "shrubb-stock-analyzer-frontend.s3-website-us-east-1.amazonaws.com"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 33,
+  "serial": 74,
   "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
   "outputs": {},
   "resources": [
@@ -101,7 +101,7 @@
             "service_registries": [],
             "tags": {},
             "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
             "timeouts": null,
             "triggers": {},
             "volume_configuration": [],
@@ -127,95 +127,6 @@
     {
       "module": "module.ecs",
       "mode": "managed",
-      "type": "aws_ecs_service",
-      "name": "frontend",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "alarms": [],
-            "availability_zone_rebalancing": "DISABLED",
-            "capacity_provider_strategy": [],
-            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
-            "deployment_circuit_breaker": [
-              {
-                "enable": false,
-                "rollback": false
-              }
-            ],
-            "deployment_controller": [
-              {
-                "type": "ECS"
-              }
-            ],
-            "deployment_maximum_percent": 200,
-            "deployment_minimum_healthy_percent": 100,
-            "desired_count": 1,
-            "enable_ecs_managed_tags": false,
-            "enable_execute_command": false,
-            "force_delete": null,
-            "force_new_deployment": null,
-            "health_check_grace_period_seconds": 0,
-            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
-            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/frontend-service",
-            "launch_type": "FARGATE",
-            "load_balancer": [
-              {
-                "container_name": "frontend",
-                "container_port": 80,
-                "elb_name": "",
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4"
-              }
-            ],
-            "name": "frontend-service",
-            "network_configuration": [
-              {
-                "assign_public_ip": true,
-                "security_groups": [
-                  "sg-042b54e04d09d4588"
-                ],
-                "subnets": [
-                  "subnet-0a2b4b43925401a30",
-                  "subnet-0c3b58546b6dff7dd"
-                ]
-              }
-            ],
-            "ordered_placement_strategy": [],
-            "placement_constraints": [],
-            "platform_version": "LATEST",
-            "propagate_tags": "NONE",
-            "scheduling_strategy": "REPLICA",
-            "service_connect_configuration": [],
-            "service_registries": [],
-            "tags": {},
-            "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
-            "timeouts": null,
-            "triggers": {},
-            "volume_configuration": [],
-            "vpc_lattice_configurations": [],
-            "wait_for_steady_state": false
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.ecs.aws_ecs_cluster.main",
-            "module.ecs.aws_ecs_task_definition.frontend",
-            "module.ecs.aws_iam_role.ecs_task_execution",
-            "module.ecs.aws_security_group.ecs_tasks",
-            "module.network.aws_lb_target_group.frontend",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.ecs",
-      "mode": "managed",
       "type": "aws_ecs_task_definition",
       "name": "backend",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -223,9 +134,9 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
             "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
             "cpu": "256",
             "enable_fault_injection": false,
             "ephemeral_storage": [],
@@ -242,54 +153,7 @@
             "requires_compatibilities": [
               "FARGATE"
             ],
-            "revision": 1,
-            "runtime_platform": [],
-            "skip_destroy": false,
-            "tags": {},
-            "tags_all": {},
-            "task_role_arn": "",
-            "track_latest": false,
-            "volume": []
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
-          "dependencies": [
-            "module.ecs.aws_iam_role.ecs_task_execution"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.ecs",
-      "mode": "managed",
-      "type": "aws_ecs_task_definition",
-      "name": "frontend",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
-            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest\",\"mountPoints\":[],\"name\":\"frontend\",\"portMappings\":[{\"containerPort\":80,\"hostPort\":80,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
-            "cpu": "256",
-            "enable_fault_injection": false,
-            "ephemeral_storage": [],
-            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
-            "family": "frontend-task",
-            "id": "frontend-task",
-            "inference_accelerator": [],
-            "ipc_mode": "",
-            "memory": "512",
-            "network_mode": "awsvpc",
-            "pid_mode": "",
-            "placement_constraints": [],
-            "proxy_configuration": [],
-            "requires_compatibilities": [
-              "FARGATE"
-            ],
-            "revision": 1,
+            "revision": 3,
             "runtime_platform": [],
             "skip_destroy": false,
             "tags": {},
@@ -484,12 +348,12 @@
       "mode": "managed",
       "type": "aws_acm_certificate",
       "name": "cert",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"].us_east_1",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:acm:us-east-2:896924684176:certificate/5060e5a3-c08c-400b-8b84-2007bfa40c51",
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
             "certificate_authority_arn": "",
             "certificate_body": null,
             "certificate_chain": null,
@@ -503,10 +367,10 @@
               }
             ],
             "early_renewal_duration": "",
-            "id": "arn:aws:acm:us-east-2:896924684176:certificate/5060e5a3-c08c-400b-8b84-2007bfa40c51",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
             "key_algorithm": "RSA_2048",
-            "not_after": "",
-            "not_before": "",
+            "not_after": "2026-07-12T23:59:59Z",
+            "not_before": "2025-06-13T00:00:00Z",
             "options": [
               {
                 "certificate_transparency_logging_preference": "ENABLED"
@@ -514,9 +378,9 @@
             ],
             "pending_renewal": false,
             "private_key": null,
-            "renewal_eligibility": "INELIGIBLE",
+            "renewal_eligibility": "ELIGIBLE",
             "renewal_summary": [],
-            "status": "PENDING_VALIDATION",
+            "status": "ISSUED",
             "subject_alternative_names": [
               "stock-analyzer.shrubb.ai"
             ],
@@ -744,126 +608,6 @@
     {
       "module": "module.network",
       "mode": "managed",
-      "type": "aws_lb_listener_rule",
-      "name": "backend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
-                "type": "forward"
-              }
-            ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
-            "condition": [
-              {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
-                  {
-                    "values": [
-                      "/predict"
-                    ]
-                  }
-                ],
-                "query_string": [],
-                "source_ip": []
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "priority": 101,
-            "tags": {},
-            "tags_all": {}
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.http",
-            "module.network.aws_lb_target_group.backend",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_listener_rule",
-      "name": "frontend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-                "type": "forward"
-              }
-            ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
-            "condition": [
-              {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
-                  {
-                    "values": [
-                      "/"
-                    ]
-                  }
-                ],
-                "query_string": [],
-                "source_ip": []
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "priority": 100,
-            "tags": {},
-            "tags_all": {}
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.http",
-            "module.network.aws_lb_target_group.frontend",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
       "type": "aws_lb_target_group",
       "name": "backend",
       "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -881,7 +625,7 @@
                 "healthy_threshold": 2,
                 "interval": 30,
                 "matcher": "200",
-                "path": "/predict",
+                "path": "/health",
                 "port": "traffic-port",
                 "protocol": "HTTP",
                 "timeout": 5,
@@ -891,109 +635,13 @@
             "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
             "ip_address_type": "ipv4",
             "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [
-              "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958"
-            ],
+            "load_balancer_arns": [],
             "load_balancing_algorithm_type": "round_robin",
             "load_balancing_anomaly_mitigation": "off",
             "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
             "name": "backend-tg",
             "name_prefix": "",
             "port": 8000,
-            "preserve_client_ip": null,
-            "protocol": "HTTP",
-            "protocol_version": "HTTP1",
-            "proxy_protocol_v2": false,
-            "slow_start": 0,
-            "stickiness": [
-              {
-                "cookie_duration": 86400,
-                "cookie_name": "",
-                "enabled": false,
-                "type": "lb_cookie"
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "target_failover": [
-              {
-                "on_deregistration": null,
-                "on_unhealthy": null
-              }
-            ],
-            "target_group_health": [
-              {
-                "dns_failover": [
-                  {
-                    "minimum_healthy_targets_count": "1",
-                    "minimum_healthy_targets_percentage": "off"
-                  }
-                ],
-                "unhealthy_state_routing": [
-                  {
-                    "minimum_healthy_targets_count": 1,
-                    "minimum_healthy_targets_percentage": "off"
-                  }
-                ]
-              }
-            ],
-            "target_health_state": [
-              {
-                "enable_unhealthy_connection_termination": null,
-                "unhealthy_draining_interval": null
-              }
-            ],
-            "target_type": "ip",
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_vpc.main"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_target_group",
-      "name": "frontend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "arn_suffix": "targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "connection_termination": null,
-            "deregistration_delay": "300",
-            "health_check": [
-              {
-                "enabled": true,
-                "healthy_threshold": 2,
-                "interval": 30,
-                "matcher": "200",
-                "path": "/",
-                "port": "traffic-port",
-                "protocol": "HTTP",
-                "timeout": 5,
-                "unhealthy_threshold": 2
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "ip_address_type": "ipv4",
-            "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [
-              "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958"
-            ],
-            "load_balancing_algorithm_type": "round_robin",
-            "load_balancing_anomaly_mitigation": "off",
-            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
-            "name": "frontend-tg",
-            "name_prefix": "",
-            "port": 80,
             "preserve_client_ip": null,
             "protocol": "HTTP",
             "protocol_version": "HTTP1",
@@ -1393,6 +1041,363 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_cloudfront_distribution",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "aliases": [
+              "stock-analyzer.shrubb.ai"
+            ],
+            "arn": "arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0",
+            "caller_reference": "terraform-20250613165906122800000001",
+            "comment": null,
+            "continuous_deployment_policy_id": "",
+            "custom_error_response": [
+              {
+                "error_caching_min_ttl": 0,
+                "error_code": 404,
+                "response_code": 200,
+                "response_page_path": "/index.html"
+              }
+            ],
+            "default_cache_behavior": [
+              {
+                "allowed_methods": [
+                  "GET",
+                  "HEAD"
+                ],
+                "cache_policy_id": "",
+                "cached_methods": [
+                  "GET",
+                  "HEAD"
+                ],
+                "compress": false,
+                "default_ttl": 0,
+                "field_level_encryption_id": "",
+                "forwarded_values": [
+                  {
+                    "cookies": [
+                      {
+                        "forward": "none",
+                        "whitelisted_names": []
+                      }
+                    ],
+                    "headers": [],
+                    "query_string": false,
+                    "query_string_cache_keys": []
+                  }
+                ],
+                "function_association": [],
+                "grpc_config": [
+                  {
+                    "enabled": false
+                  }
+                ],
+                "lambda_function_association": [],
+                "max_ttl": 0,
+                "min_ttl": 0,
+                "origin_request_policy_id": "",
+                "realtime_log_config_arn": "",
+                "response_headers_policy_id": "",
+                "smooth_streaming": false,
+                "target_origin_id": "frontend-origin",
+                "trusted_key_groups": [],
+                "trusted_signers": [],
+                "viewer_protocol_policy": "redirect-to-https"
+              }
+            ],
+            "default_root_object": "index.html",
+            "domain_name": "d2g86i0wrkfe7n.cloudfront.net",
+            "enabled": true,
+            "etag": "EQAP9R7SKEFU4",
+            "hosted_zone_id": "Z2FDTNDATAQYW2",
+            "http_version": "http2",
+            "id": "E14Q29W1T4EPG0",
+            "in_progress_validation_batches": 0,
+            "is_ipv6_enabled": true,
+            "last_modified_time": "2025-06-13 17:34:15.562 +0000 UTC",
+            "logging_config": [],
+            "ordered_cache_behavior": [],
+            "origin": [
+              {
+                "connection_attempts": 3,
+                "connection_timeout": 10,
+                "custom_header": [],
+                "custom_origin_config": [],
+                "domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+                "origin_access_control_id": "EF0CVC5NFHZ5L",
+                "origin_id": "frontend-origin",
+                "origin_path": "",
+                "origin_shield": [],
+                "s3_origin_config": [],
+                "vpc_origin_config": []
+              }
+            ],
+            "origin_group": [],
+            "price_class": "PriceClass_All",
+            "restrictions": [
+              {
+                "geo_restriction": [
+                  {
+                    "locations": [],
+                    "restriction_type": "none"
+                  }
+                ]
+              }
+            ],
+            "retain_on_delete": false,
+            "staging": false,
+            "status": "Deployed",
+            "tags": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "tags_all": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "trusted_key_groups": [
+              {
+                "enabled": false,
+                "items": []
+              }
+            ],
+            "trusted_signers": [
+              {
+                "enabled": false,
+                "items": []
+              }
+            ],
+            "viewer_certificate": [
+              {
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+                "cloudfront_default_certificate": false,
+                "iam_certificate_id": "",
+                "minimum_protocol_version": "TLSv1.2_2021",
+                "ssl_support_method": "sni-only"
+              }
+            ],
+            "wait_for_deployment": true,
+            "web_acl_id": ""
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_cloudfront_origin_access_control",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/EF0CVC5NFHZ5L",
+            "description": "OAC for S3 frontend",
+            "etag": "ETVPDKIKX0DER",
+            "id": "EF0CVC5NFHZ5L",
+            "name": "frontend-oac",
+            "origin_access_control_origin_type": "s3",
+            "signing_behavior": "always",
+            "signing_protocol": "sigv4"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "bucket_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": true,
+            "grant": [
+              {
+                "id": "cc7ec2d396e31a7d8694c7b01281c323af23ae26a419de041c3bbabb7f36df65",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z2O1EMRO9K5GLX",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "tags_all": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [
+              {
+                "error_document": "index.html",
+                "index_document": "index.html",
+                "redirect_all_requests_to": "",
+                "routing_rules": ""
+              }
+            ],
+            "website_domain": "s3-website.us-east-2.amazonaws.com",
+            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket_policy",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-ai-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.s3cloudfront.aws_cloudfront_distribution.frontend",
+            "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket_website_configuration",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "error_document": [
+              {
+                "key": "index.html"
+              }
+            ],
+            "expected_bucket_owner": "",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "index_document": [
+              {
+                "suffix": "index.html"
+              }
+            ],
+            "redirect_all_requests_to": [],
+            "routing_rule": [],
+            "routing_rules": "",
+            "website_domain": "s3-website.us-east-2.amazonaws.com",
+            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
         }
       ]
     }

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,0 +1,1401 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 33,
+  "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_cluster",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "configuration": [],
+            "id": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "name": "stock-analyzer-cluster",
+            "service_connect_defaults": [],
+            "setting": [
+              {
+                "name": "containerInsights",
+                "value": "disabled"
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "alarms": [],
+            "availability_zone_rebalancing": "DISABLED",
+            "capacity_provider_strategy": [],
+            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [
+              {
+                "type": "ECS"
+              }
+            ],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 100,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": null,
+            "health_check_grace_period_seconds": 0,
+            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/backend-service",
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "container_name": "backend",
+                "container_port": 8000,
+                "elb_name": "",
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db"
+              }
+            ],
+            "name": "backend-service",
+            "network_configuration": [
+              {
+                "assign_public_ip": true,
+                "security_groups": [
+                  "sg-042b54e04d09d4588"
+                ],
+                "subnets": [
+                  "subnet-0a2b4b43925401a30",
+                  "subnet-0c3b58546b6dff7dd"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "platform_version": "LATEST",
+            "propagate_tags": "NONE",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [],
+            "service_registries": [],
+            "tags": {},
+            "tags_all": {},
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "timeouts": null,
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": false
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.ecs.aws_ecs_cluster.main",
+            "module.ecs.aws_ecs_task_definition.backend",
+            "module.ecs.aws_iam_role.ecs_task_execution",
+            "module.ecs.aws_security_group.ecs_tasks",
+            "module.network.aws_lb_target_group.backend",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "frontend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "alarms": [],
+            "availability_zone_rebalancing": "DISABLED",
+            "capacity_provider_strategy": [],
+            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [
+              {
+                "type": "ECS"
+              }
+            ],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 100,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": null,
+            "health_check_grace_period_seconds": 0,
+            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/frontend-service",
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "container_name": "frontend",
+                "container_port": 80,
+                "elb_name": "",
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4"
+              }
+            ],
+            "name": "frontend-service",
+            "network_configuration": [
+              {
+                "assign_public_ip": true,
+                "security_groups": [
+                  "sg-042b54e04d09d4588"
+                ],
+                "subnets": [
+                  "subnet-0a2b4b43925401a30",
+                  "subnet-0c3b58546b6dff7dd"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "platform_version": "LATEST",
+            "propagate_tags": "NONE",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [],
+            "service_registries": [],
+            "tags": {},
+            "tags_all": {},
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
+            "timeouts": null,
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": false
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.ecs.aws_ecs_cluster.main",
+            "module.ecs.aws_ecs_task_definition.frontend",
+            "module.ecs.aws_iam_role.ecs_task_execution",
+            "module.ecs.aws_security_group.ecs_tasks",
+            "module.network.aws_lb_target_group.frontend",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "cpu": "256",
+            "enable_fault_injection": false,
+            "ephemeral_storage": [],
+            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "family": "backend-task",
+            "id": "backend-task",
+            "inference_accelerator": [],
+            "ipc_mode": "",
+            "memory": "512",
+            "network_mode": "awsvpc",
+            "pid_mode": "",
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "revision": 1,
+            "runtime_platform": [],
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {},
+            "task_role_arn": "",
+            "track_latest": false,
+            "volume": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "frontend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
+            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest\",\"mountPoints\":[],\"name\":\"frontend\",\"portMappings\":[{\"containerPort\":80,\"hostPort\":80,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "cpu": "256",
+            "enable_fault_injection": false,
+            "ephemeral_storage": [],
+            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "family": "frontend-task",
+            "id": "frontend-task",
+            "inference_accelerator": [],
+            "ipc_mode": "",
+            "memory": "512",
+            "network_mode": "awsvpc",
+            "pid_mode": "",
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "revision": 1,
+            "runtime_platform": [],
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {},
+            "task_role_arn": "",
+            "track_latest": false,
+            "volume": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "ecs_task_execution",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "create_date": "2025-06-12T16:45:38Z",
+            "description": "",
+            "force_detach_policies": false,
+            "id": "ecsTaskExecutionRole",
+            "inline_policy": [],
+            "managed_policy_arns": [
+              "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+            ],
+            "max_session_duration": 3600,
+            "name": "ecsTaskExecutionRole",
+            "name_prefix": "",
+            "path": "/",
+            "permissions_boundary": "",
+            "tags": {},
+            "tags_all": {},
+            "unique_id": "AROA5BVHAR6IEKMAKZELH"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_iam_role_policy_attachment",
+      "name": "ecs_execution_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "ecsTaskExecutionRole-20250612164537129100000001",
+            "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+            "role": "ecsTaskExecutionRole"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "ecs_tasks",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-042b54e04d09d4588",
+            "description": "Allow traffic from ALB to ECS tasks",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-042b54e04d09d4588",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 8000,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 8000
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "ecs-tasks-sg",
+            "name_prefix": "",
+            "owner_id": "896924684176",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "ecs-tasks-sg"
+            },
+            "tags_all": {
+              "Name": "ecs-tasks-sg"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "data",
+      "type": "aws_availability_zones",
+      "name": "available",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "all_availability_zones": null,
+            "exclude_names": null,
+            "exclude_zone_ids": null,
+            "filter": null,
+            "group_names": [
+              "us-east-2-zg-1"
+            ],
+            "id": "us-east-2",
+            "names": [
+              "us-east-2a",
+              "us-east-2b",
+              "us-east-2c"
+            ],
+            "state": null,
+            "timeouts": null,
+            "zone_ids": [
+              "use2-az1",
+              "use2-az2",
+              "use2-az3"
+            ]
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_acm_certificate",
+      "name": "cert",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:acm:us-east-2:896924684176:certificate/5060e5a3-c08c-400b-8b84-2007bfa40c51",
+            "certificate_authority_arn": "",
+            "certificate_body": null,
+            "certificate_chain": null,
+            "domain_name": "stock-analyzer.shrubb.ai",
+            "domain_validation_options": [
+              {
+                "domain_name": "stock-analyzer.shrubb.ai",
+                "resource_record_name": "_dc6ab177e18740b49a0fa48dc9d9ba85.stock-analyzer.shrubb.ai.",
+                "resource_record_type": "CNAME",
+                "resource_record_value": "_e68fc804ab950f50915a3adb4105d0f9.xlfgrmvvlj.acm-validations.aws."
+              }
+            ],
+            "early_renewal_duration": "",
+            "id": "arn:aws:acm:us-east-2:896924684176:certificate/5060e5a3-c08c-400b-8b84-2007bfa40c51",
+            "key_algorithm": "RSA_2048",
+            "not_after": "",
+            "not_before": "",
+            "options": [
+              {
+                "certificate_transparency_logging_preference": "ENABLED"
+              }
+            ],
+            "pending_renewal": false,
+            "private_key": null,
+            "renewal_eligibility": "INELIGIBLE",
+            "renewal_summary": [],
+            "status": "PENDING_VALIDATION",
+            "subject_alternative_names": [
+              "stock-analyzer.shrubb.ai"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-cert"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-cert"
+            },
+            "type": "AMAZON_ISSUED",
+            "validation_emails": [],
+            "validation_method": "DNS",
+            "validation_option": []
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "private_key"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "gw",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:internet-gateway/igw-0fa0bc93b789a7643",
+            "id": "igw-0fa0bc93b789a7643",
+            "owner_id": "896924684176",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb",
+      "name": "main",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_logs": [
+              {
+                "bucket": "",
+                "enabled": false,
+                "prefix": ""
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "arn_suffix": "app/stock-analyzer-alb/f81c590316270958",
+            "client_keep_alive": 3600,
+            "connection_logs": [
+              {
+                "bucket": "",
+                "enabled": false,
+                "prefix": ""
+              }
+            ],
+            "customer_owned_ipv4_pool": "",
+            "desync_mitigation_mode": "defensive",
+            "dns_name": "stock-analyzer-alb-1551012673.us-east-2.elb.amazonaws.com",
+            "dns_record_client_routing_policy": null,
+            "drop_invalid_header_fields": false,
+            "enable_cross_zone_load_balancing": true,
+            "enable_deletion_protection": false,
+            "enable_http2": true,
+            "enable_tls_version_and_cipher_suite_headers": false,
+            "enable_waf_fail_open": false,
+            "enable_xff_client_port": false,
+            "enable_zonal_shift": false,
+            "enforce_security_group_inbound_rules_on_private_link_traffic": "",
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "idle_timeout": 60,
+            "internal": false,
+            "ip_address_type": "ipv4",
+            "ipam_pools": [],
+            "load_balancer_type": "application",
+            "minimum_load_balancer_capacity": [],
+            "name": "stock-analyzer-alb",
+            "name_prefix": "",
+            "preserve_host_header": false,
+            "security_groups": [
+              "sg-0849043bdcac304cd"
+            ],
+            "subnet_mapping": [
+              {
+                "allocation_id": "",
+                "ipv6_address": "",
+                "outpost_id": "",
+                "private_ipv4_address": "",
+                "subnet_id": "subnet-0a2b4b43925401a30"
+              },
+              {
+                "allocation_id": "",
+                "ipv6_address": "",
+                "outpost_id": "",
+                "private_ipv4_address": "",
+                "subnet_id": "subnet-0c3b58546b6dff7dd"
+              }
+            ],
+            "subnets": [
+              "subnet-0a2b4b43925401a30",
+              "subnet-0c3b58546b6dff7dd"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-alb"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-alb"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a",
+            "xff_header_processing_mode": "append",
+            "zone_id": "Z3AADJGX6KTTL2"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener",
+      "name": "http",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "alpn_policy": null,
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [
+                  {
+                    "content_type": "text/plain",
+                    "message_body": "Default backend reached",
+                    "status_code": "404"
+                  }
+                ],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "",
+                "type": "fixed-response"
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "mutual_authentication": [],
+            "port": 80,
+            "protocol": "HTTP",
+            "routing_http_request_x_amzn_mtls_clientcert_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": null,
+            "routing_http_request_x_amzn_tls_cipher_suite_header_name": null,
+            "routing_http_request_x_amzn_tls_version_header_name": null,
+            "routing_http_response_access_control_allow_credentials_header_value": "",
+            "routing_http_response_access_control_allow_headers_header_value": "",
+            "routing_http_response_access_control_allow_methods_header_value": "",
+            "routing_http_response_access_control_allow_origin_header_value": "",
+            "routing_http_response_access_control_expose_headers_header_value": "",
+            "routing_http_response_access_control_max_age_header_value": "",
+            "routing_http_response_content_security_policy_header_value": "",
+            "routing_http_response_server_enabled": true,
+            "routing_http_response_strict_transport_security_header_value": "",
+            "routing_http_response_x_content_type_options_header_value": "",
+            "routing_http_response_x_frame_options_header_value": "",
+            "ssl_policy": "",
+            "tags": {},
+            "tags_all": {},
+            "tcp_idle_timeout_seconds": null,
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "backend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/predict"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "priority": 101,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.http",
+            "module.network.aws_lb_target_group.backend",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "frontend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "priority": 100,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.http",
+            "module.network.aws_lb_target_group.frontend",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_target_group",
+      "name": "backend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "arn_suffix": "targetgroup/backend-tg/4bb7268be23e80db",
+            "connection_termination": null,
+            "deregistration_delay": "300",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "matcher": "200",
+                "path": "/predict",
+                "port": "traffic-port",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "ip_address_type": "ipv4",
+            "lambda_multi_value_headers_enabled": false,
+            "load_balancer_arns": [
+              "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958"
+            ],
+            "load_balancing_algorithm_type": "round_robin",
+            "load_balancing_anomaly_mitigation": "off",
+            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
+            "name": "backend-tg",
+            "name_prefix": "",
+            "port": 8000,
+            "preserve_client_ip": null,
+            "protocol": "HTTP",
+            "protocol_version": "HTTP1",
+            "proxy_protocol_v2": false,
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 86400,
+                "cookie_name": "",
+                "enabled": false,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "target_failover": [
+              {
+                "on_deregistration": null,
+                "on_unhealthy": null
+              }
+            ],
+            "target_group_health": [
+              {
+                "dns_failover": [
+                  {
+                    "minimum_healthy_targets_count": "1",
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ],
+                "unhealthy_state_routing": [
+                  {
+                    "minimum_healthy_targets_count": 1,
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ]
+              }
+            ],
+            "target_health_state": [
+              {
+                "enable_unhealthy_connection_termination": null,
+                "unhealthy_draining_interval": null
+              }
+            ],
+            "target_type": "ip",
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_target_group",
+      "name": "frontend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "arn_suffix": "targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "connection_termination": null,
+            "deregistration_delay": "300",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "matcher": "200",
+                "path": "/",
+                "port": "traffic-port",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "ip_address_type": "ipv4",
+            "lambda_multi_value_headers_enabled": false,
+            "load_balancer_arns": [
+              "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958"
+            ],
+            "load_balancing_algorithm_type": "round_robin",
+            "load_balancing_anomaly_mitigation": "off",
+            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
+            "name": "frontend-tg",
+            "name_prefix": "",
+            "port": 80,
+            "preserve_client_ip": null,
+            "protocol": "HTTP",
+            "protocol_version": "HTTP1",
+            "proxy_protocol_v2": false,
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 86400,
+                "cookie_name": "",
+                "enabled": false,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "target_failover": [
+              {
+                "on_deregistration": null,
+                "on_unhealthy": null
+              }
+            ],
+            "target_group_health": [
+              {
+                "dns_failover": [
+                  {
+                    "minimum_healthy_targets_count": "1",
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ],
+                "unhealthy_state_routing": [
+                  {
+                    "minimum_healthy_targets_count": 1,
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ]
+              }
+            ],
+            "target_health_state": [
+              {
+                "enable_unhealthy_connection_termination": null,
+                "unhealthy_draining_interval": null
+              }
+            ],
+            "target_type": "ip",
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "internet_access",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": "",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "",
+            "gateway_id": "igw-0fa0bc93b789a7643",
+            "id": "r-rtb-0c3bad089d9c13adc1080289494",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "state": "active",
+            "timeouts": null,
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_internet_gateway.gw",
+            "module.network.aws_route_table.public",
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:route-table/rtb-0c3bad089d9c13adc",
+            "id": "rtb-0c3bad089d9c13adc",
+            "owner_id": "896924684176",
+            "propagating_vgws": [],
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "igw-0fa0bc93b789a7643",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-0644356cbf9fcd16a",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "subnet_id": "subnet-0a2b4b43925401a30",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_route_table.public",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-061959307ae8430b0",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "subnet_id": "subnet-0c3b58546b6dff7dd",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_route_table.public",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "alb",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-0849043bdcac304cd",
+            "description": "Allow HTTP/HTTPS inbound traffic",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-0849043bdcac304cd",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 443
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "alb-sg",
+            "name_prefix": "",
+            "owner_id": "896924684176",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "alb-sg"
+            },
+            "tags_all": {
+              "Name": "alb-sg"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0a2b4b43925401a30",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2a",
+            "availability_zone_id": "use2-az1",
+            "cidr_block": "10.0.0.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0a2b4b43925401a30",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": true,
+            "outpost_arn": "",
+            "owner_id": "896924684176",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "stock-public-0"
+            },
+            "tags_all": {
+              "Name": "stock-public-0"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0c3b58546b6dff7dd",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2b",
+            "availability_zone_id": "use2-az2",
+            "cidr_block": "10.0.16.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0c3b58546b6dff7dd",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": true,
+            "outpost_arn": "",
+            "owner_id": "896924684176",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "stock-public-1"
+            },
+            "tags_all": {
+              "Name": "stock-public-1"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:vpc/vpc-0e677828b4dc5fa9a",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-0686f8d4be1e2c8dc",
+            "default_route_table_id": "rtb-0509e12dac3222b5d",
+            "default_security_group_id": "sg-010ecb86c454dda99",
+            "dhcp_options_id": "dopt-08834e4367484cb08",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-0e677828b4dc5fa9a",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-0509e12dac3222b5d",
+            "owner_id": "896924684176",
+            "tags": {
+              "Name": "stock-vpc"
+            },
+            "tags_all": {
+              "Name": "stock-vpc"
+            }
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 45,
+  "serial": 57,
   "lineage": "502feed0-8c80-a89e-54b6-eae94b4ea6d0",
   "outputs": {},
   "resources": [
@@ -156,7 +156,7 @@
             "revision": 2,
             "runtime_platform": [],
             "skip_destroy": false,
-            "tags": null,
+            "tags": {},
             "tags_all": {},
             "task_role_arn": "",
             "track_latest": false,
@@ -353,13 +353,78 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_acm_certificate",
-      "name": "cert",
+      "name": "backend_cert",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/713c7be0-e61d-4aaa-b30f-59c62baf42dd",
+            "certificate_authority_arn": "",
+            "certificate_body": null,
+            "certificate_chain": null,
+            "domain_name": "api.stock-analyzer.shrubb.ai",
+            "domain_validation_options": [
+              {
+                "domain_name": "api.stock-analyzer.shrubb.ai",
+                "resource_record_name": "_41f89e8e05d3f55ebc54c2a01b03e71d.api.stock-analyzer.shrubb.ai.",
+                "resource_record_type": "CNAME",
+                "resource_record_value": "_ed578493a0ee823c7b74b9853c70c194.xlfgrmvvlj.acm-validations.aws."
+              }
+            ],
+            "early_renewal_duration": "",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/713c7be0-e61d-4aaa-b30f-59c62baf42dd",
+            "key_algorithm": "RSA_2048",
+            "not_after": "2026-07-16T23:59:59Z",
+            "not_before": "2025-06-17T00:00:00Z",
+            "options": [
+              {
+                "certificate_transparency_logging_preference": "ENABLED"
+              }
+            ],
+            "pending_renewal": false,
+            "private_key": null,
+            "renewal_eligibility": "INELIGIBLE",
+            "renewal_summary": [],
+            "status": "ISSUED",
+            "subject_alternative_names": [
+              "api.stock-analyzer.shrubb.ai"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-backend-cert"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-backend-cert"
+            },
+            "type": "AMAZON_ISSUED",
+            "validation_emails": [],
+            "validation_method": "DNS",
+            "validation_option": []
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "private_key"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_acm_certificate",
+      "name": "frontend_cert",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
             "certificate_authority_arn": "",
             "certificate_body": null,
             "certificate_chain": null,
@@ -373,7 +438,7 @@
               }
             ],
             "early_renewal_duration": "",
-            "id": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
             "key_algorithm": "RSA_2048",
             "not_after": "2026-07-15T23:59:59Z",
             "not_before": "2025-06-16T00:00:00Z",
@@ -391,10 +456,10 @@
               "stock-analyzer.shrubb.ai"
             ],
             "tags": {
-              "Name": "stock-analyzer-cert"
+              "Name": "stock-analyzer-frontend-cert"
             },
             "tags_all": {
-              "Name": "stock-analyzer-cert"
+              "Name": "stock-analyzer-frontend-cert"
             },
             "type": "AMAZON_ISSUED",
             "validation_emails": [],
@@ -541,34 +606,28 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_lb_listener",
-      "name": "https",
+      "name": "https_backend",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "alpn_policy": null,
-            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
-            "certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/afd5dbc9adcea49d",
+            "certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/713c7be0-e61d-4aaa-b30f-59c62baf42dd",
             "default_action": [
               {
                 "authenticate_cognito": [],
                 "authenticate_oidc": [],
-                "fixed_response": [
-                  {
-                    "content_type": "text/plain",
-                    "message_body": "Not found",
-                    "status_code": "404"
-                  }
-                ],
+                "fixed_response": [],
                 "forward": [],
                 "order": 1,
                 "redirect": [],
-                "target_group_arn": "",
-                "type": "fixed-response"
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
+                "type": "forward"
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/afd5dbc9adcea49d",
             "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
             "mutual_authentication": [
               {
@@ -600,7 +659,7 @@
             "routing_http_response_x_content_type_options_header_value": "",
             "routing_http_response_x_frame_options_header_value": "",
             "ssl_policy": "ELBSecurityPolicy-2016-08",
-            "tags": {},
+            "tags": null,
             "tags_all": {},
             "tcp_idle_timeout_seconds": null,
             "timeouts": null
@@ -609,8 +668,9 @@
           "identity_schema_version": 0,
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.backend_cert",
             "module.network.aws_lb.main",
+            "module.network.aws_lb_target_group.backend",
             "module.network.aws_security_group.alb",
             "module.network.aws_subnet.public",
             "module.network.aws_vpc.main",
@@ -623,7 +683,7 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_lb_listener_rule",
-      "name": "api_routing",
+      "name": "api_host_routing",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
@@ -641,36 +701,36 @@
                 "type": "forward"
               }
             ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/afd5dbc9adcea49d/f8fcc6fd9b914b1f",
             "condition": [
               {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
+                "host_header": [
                   {
                     "values": [
-                      "/api/*"
+                      "api.stockanalyzer.shrubb.ai"
                     ]
                   }
                 ],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [],
                 "query_string": [],
                 "source_ip": []
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
-            "priority": 20,
-            "tags": {},
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/afd5dbc9adcea49d/f8fcc6fd9b914b1f",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/afd5dbc9adcea49d",
+            "priority": 10,
+            "tags": null,
             "tags_all": {}
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "private": "bnVsbA==",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.backend_cert",
             "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.https",
+            "module.network.aws_lb_listener.https_backend",
             "module.network.aws_lb_target_group.backend",
             "module.network.aws_security_group.alb",
             "module.network.aws_subnet.public",
@@ -710,9 +770,7 @@
             "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
             "ip_address_type": "ipv4",
             "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [
-              "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430"
-            ],
+            "load_balancer_arns": [],
             "load_balancing_algorithm_type": "round_robin",
             "load_balancing_anomaly_mitigation": "off",
             "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
@@ -1195,13 +1253,13 @@
             "default_root_object": "index.html",
             "domain_name": "dxoccp6gw8qk3.cloudfront.net",
             "enabled": true,
-            "etag": "E1N0T1754BGVZW",
+            "etag": "E1VMUR6BB9BO98",
             "hosted_zone_id": "Z2FDTNDATAQYW2",
             "http_version": "http2",
             "id": "E3R6TRBTP0FQ33",
             "in_progress_validation_batches": 0,
             "is_ipv6_enabled": true,
-            "last_modified_time": "2025-06-16 16:41:19.633 +0000 UTC",
+            "last_modified_time": "2025-06-17 02:39:20.374 +0000 UTC",
             "logging_config": [],
             "ordered_cache_behavior": [],
             "origin": [
@@ -1233,7 +1291,7 @@
             ],
             "retain_on_delete": false,
             "staging": false,
-            "status": "Deployed",
+            "status": "InProgress",
             "tags": {
               "Env": "prod",
               "Project": "StockAnalyzer"
@@ -1256,7 +1314,7 @@
             ],
             "viewer_certificate": [
               {
-                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
                 "cloudfront_default_certificate": false,
                 "iam_certificate_id": "",
                 "minimum_protocol_version": "TLSv1.2_2021",
@@ -1270,7 +1328,7 @@
           "identity_schema_version": 0,
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.frontend_cert",
             "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
             "module.s3cloudfront.aws_s3_bucket.frontend"
           ]
@@ -1406,7 +1464,7 @@
           "identity_schema_version": 0,
           "private": "bnVsbA==",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.frontend_cert",
             "module.s3cloudfront.aws_cloudfront_distribution.frontend",
             "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
             "module.s3cloudfront.aws_s3_bucket.frontend"

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 41,
+  "serial": 54,
   "lineage": "502feed0-8c80-a89e-54b6-eae94b4ea6d0",
   "outputs": {},
   "resources": [
@@ -101,7 +101,7 @@
             "service_registries": [],
             "tags": {},
             "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:1",
+            "task_definition": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:2",
             "timeouts": null,
             "triggers": {},
             "volume_configuration": [],
@@ -134,9 +134,9 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:1",
+            "arn": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:2",
             "arn_without_revision": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend:v0.0.1\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
             "cpu": "256",
             "enable_fault_injection": false,
             "ephemeral_storage": [],
@@ -153,7 +153,7 @@
             "requires_compatibilities": [
               "FARGATE"
             ],
-            "revision": 1,
+            "revision": 2,
             "runtime_platform": [],
             "skip_destroy": false,
             "tags": {},
@@ -353,13 +353,78 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_acm_certificate",
-      "name": "cert",
+      "name": "backend_cert",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/713c7be0-e61d-4aaa-b30f-59c62baf42dd",
+            "certificate_authority_arn": "",
+            "certificate_body": null,
+            "certificate_chain": null,
+            "domain_name": "api.stock-analyzer.shrubb.ai",
+            "domain_validation_options": [
+              {
+                "domain_name": "api.stock-analyzer.shrubb.ai",
+                "resource_record_name": "_41f89e8e05d3f55ebc54c2a01b03e71d.api.stock-analyzer.shrubb.ai.",
+                "resource_record_type": "CNAME",
+                "resource_record_value": "_ed578493a0ee823c7b74b9853c70c194.xlfgrmvvlj.acm-validations.aws."
+              }
+            ],
+            "early_renewal_duration": "",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/713c7be0-e61d-4aaa-b30f-59c62baf42dd",
+            "key_algorithm": "RSA_2048",
+            "not_after": "",
+            "not_before": "",
+            "options": [
+              {
+                "certificate_transparency_logging_preference": "ENABLED"
+              }
+            ],
+            "pending_renewal": false,
+            "private_key": null,
+            "renewal_eligibility": "INELIGIBLE",
+            "renewal_summary": [],
+            "status": "PENDING_VALIDATION",
+            "subject_alternative_names": [
+              "api.stock-analyzer.shrubb.ai"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-backend-cert"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-backend-cert"
+            },
+            "type": "AMAZON_ISSUED",
+            "validation_emails": [],
+            "validation_method": "DNS",
+            "validation_option": []
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "private_key"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_acm_certificate",
+      "name": "frontend_cert",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
             "certificate_authority_arn": "",
             "certificate_body": null,
             "certificate_chain": null,
@@ -373,7 +438,7 @@
               }
             ],
             "early_renewal_duration": "",
-            "id": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
             "key_algorithm": "RSA_2048",
             "not_after": "2026-07-15T23:59:59Z",
             "not_before": "2025-06-16T00:00:00Z",
@@ -391,10 +456,10 @@
               "stock-analyzer.shrubb.ai"
             ],
             "tags": {
-              "Name": "stock-analyzer-cert"
+              "Name": "stock-analyzer-frontend-cert"
             },
             "tags_all": {
-              "Name": "stock-analyzer-cert"
+              "Name": "stock-analyzer-frontend-cert"
             },
             "type": "AMAZON_ISSUED",
             "validation_emails": [],
@@ -540,149 +605,6 @@
     {
       "module": "module.network",
       "mode": "managed",
-      "type": "aws_lb_listener",
-      "name": "https",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "alpn_policy": null,
-            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
-            "certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
-            "default_action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [
-                  {
-                    "content_type": "text/plain",
-                    "message_body": "Not found",
-                    "status_code": "404"
-                  }
-                ],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "",
-                "type": "fixed-response"
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
-            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
-            "mutual_authentication": [
-              {
-                "advertise_trust_store_ca_names": "",
-                "ignore_client_certificate_expiry": false,
-                "mode": "off",
-                "trust_store_arn": ""
-              }
-            ],
-            "port": 443,
-            "protocol": "HTTPS",
-            "routing_http_request_x_amzn_mtls_clientcert_header_name": "",
-            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": "",
-            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": "",
-            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": "",
-            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": "",
-            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": "",
-            "routing_http_request_x_amzn_tls_cipher_suite_header_name": "",
-            "routing_http_request_x_amzn_tls_version_header_name": "",
-            "routing_http_response_access_control_allow_credentials_header_value": "",
-            "routing_http_response_access_control_allow_headers_header_value": "",
-            "routing_http_response_access_control_allow_methods_header_value": "",
-            "routing_http_response_access_control_allow_origin_header_value": "",
-            "routing_http_response_access_control_expose_headers_header_value": "",
-            "routing_http_response_access_control_max_age_header_value": "",
-            "routing_http_response_content_security_policy_header_value": "",
-            "routing_http_response_server_enabled": true,
-            "routing_http_response_strict_transport_security_header_value": "",
-            "routing_http_response_x_content_type_options_header_value": "",
-            "routing_http_response_x_frame_options_header_value": "",
-            "ssl_policy": "ELBSecurityPolicy-2016-08",
-            "tags": {},
-            "tags_all": {},
-            "tcp_idle_timeout_seconds": null,
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
-          "dependencies": [
-            "module.network.aws_acm_certificate.cert",
-            "module.network.aws_lb.main",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_listener_rule",
-      "name": "api_routing",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
-                "type": "forward"
-              }
-            ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
-            "condition": [
-              {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
-                  {
-                    "values": [
-                      "/api/*"
-                    ]
-                  }
-                ],
-                "query_string": [],
-                "source_ip": []
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
-            "priority": 20,
-            "tags": {},
-            "tags_all": {}
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_acm_certificate.cert",
-            "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.https",
-            "module.network.aws_lb_target_group.backend",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
       "type": "aws_lb_target_group",
       "name": "backend",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -710,9 +632,7 @@
             "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
             "ip_address_type": "ipv4",
             "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [
-              "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430"
-            ],
+            "load_balancer_arns": [],
             "load_balancing_algorithm_type": "round_robin",
             "load_balancing_anomaly_mitigation": "off",
             "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
@@ -1140,7 +1060,7 @@
             "continuous_deployment_policy_id": "",
             "custom_error_response": [
               {
-                "error_caching_min_ttl": null,
+                "error_caching_min_ttl": 0,
                 "error_code": 404,
                 "response_code": 200,
                 "response_page_path": "/index.html"
@@ -1195,13 +1115,13 @@
             "default_root_object": "index.html",
             "domain_name": "dxoccp6gw8qk3.cloudfront.net",
             "enabled": true,
-            "etag": "E1N0T1754BGVZW",
+            "etag": "E1VMUR6BB9BO98",
             "hosted_zone_id": "Z2FDTNDATAQYW2",
             "http_version": "http2",
             "id": "E3R6TRBTP0FQ33",
             "in_progress_validation_batches": 0,
             "is_ipv6_enabled": true,
-            "last_modified_time": "2025-06-16 16:41:19.633 +0000 UTC",
+            "last_modified_time": "2025-06-17 02:39:20.374 +0000 UTC",
             "logging_config": [],
             "ordered_cache_behavior": [],
             "origin": [
@@ -1233,7 +1153,7 @@
             ],
             "retain_on_delete": false,
             "staging": false,
-            "status": "Deployed",
+            "status": "InProgress",
             "tags": {
               "Env": "prod",
               "Project": "StockAnalyzer"
@@ -1256,7 +1176,7 @@
             ],
             "viewer_certificate": [
               {
-                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/e460431e-c9f9-41db-88d6-af02df38fa23",
                 "cloudfront_default_certificate": false,
                 "iam_certificate_id": "",
                 "minimum_protocol_version": "TLSv1.2_2021",
@@ -1270,7 +1190,7 @@
           "identity_schema_version": 0,
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.frontend_cert",
             "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
             "module.s3cloudfront.aws_s3_bucket.frontend"
           ]
@@ -1337,7 +1257,7 @@
             "logging": [],
             "object_lock_configuration": [],
             "object_lock_enabled": false,
-            "policy": "",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}",
             "region": "us-east-1",
             "replication_configuration": [],
             "request_payer": "BucketOwner",
@@ -1371,9 +1291,16 @@
                 "mfa_delete": false
               }
             ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
+            "website": [
+              {
+                "error_document": "index.html",
+                "index_document": "index.html",
+                "redirect_all_requests_to": "",
+                "routing_rules": ""
+              }
+            ],
+            "website_domain": "s3-website-us-east-1.amazonaws.com",
+            "website_endpoint": "shrubb-stock-analyzer-frontend.s3-website-us-east-1.amazonaws.com"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1399,7 +1326,7 @@
           "identity_schema_version": 0,
           "private": "bnVsbA==",
           "dependencies": [
-            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_acm_certificate.frontend_cert",
             "module.s3cloudfront.aws_cloudfront_distribution.frontend",
             "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
             "module.s3cloudfront.aws_s3_bucket.frontend"

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 31,
+  "serial": 72,
   "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
   "outputs": {},
   "resources": [
@@ -99,9 +99,9 @@
             "scheduling_strategy": "REPLICA",
             "service_connect_configuration": [],
             "service_registries": [],
-            "tags": null,
+            "tags": {},
             "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
             "timeouts": null,
             "triggers": {},
             "volume_configuration": [],
@@ -127,95 +127,6 @@
     {
       "module": "module.ecs",
       "mode": "managed",
-      "type": "aws_ecs_service",
-      "name": "frontend",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "alarms": [],
-            "availability_zone_rebalancing": "DISABLED",
-            "capacity_provider_strategy": [],
-            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
-            "deployment_circuit_breaker": [
-              {
-                "enable": false,
-                "rollback": false
-              }
-            ],
-            "deployment_controller": [
-              {
-                "type": "ECS"
-              }
-            ],
-            "deployment_maximum_percent": 200,
-            "deployment_minimum_healthy_percent": 100,
-            "desired_count": 1,
-            "enable_ecs_managed_tags": false,
-            "enable_execute_command": false,
-            "force_delete": null,
-            "force_new_deployment": null,
-            "health_check_grace_period_seconds": 0,
-            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
-            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/frontend-service",
-            "launch_type": "FARGATE",
-            "load_balancer": [
-              {
-                "container_name": "frontend",
-                "container_port": 80,
-                "elb_name": "",
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4"
-              }
-            ],
-            "name": "frontend-service",
-            "network_configuration": [
-              {
-                "assign_public_ip": true,
-                "security_groups": [
-                  "sg-042b54e04d09d4588"
-                ],
-                "subnets": [
-                  "subnet-0a2b4b43925401a30",
-                  "subnet-0c3b58546b6dff7dd"
-                ]
-              }
-            ],
-            "ordered_placement_strategy": [],
-            "placement_constraints": [],
-            "platform_version": "LATEST",
-            "propagate_tags": "NONE",
-            "scheduling_strategy": "REPLICA",
-            "service_connect_configuration": [],
-            "service_registries": [],
-            "tags": null,
-            "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
-            "timeouts": null,
-            "triggers": {},
-            "volume_configuration": [],
-            "vpc_lattice_configurations": [],
-            "wait_for_steady_state": false
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.ecs.aws_ecs_cluster.main",
-            "module.ecs.aws_ecs_task_definition.frontend",
-            "module.ecs.aws_iam_role.ecs_task_execution",
-            "module.ecs.aws_security_group.ecs_tasks",
-            "module.network.aws_lb_target_group.frontend",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.ecs",
-      "mode": "managed",
       "type": "aws_ecs_task_definition",
       "name": "backend",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -223,9 +134,9 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
             "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
             "cpu": "256",
             "enable_fault_injection": false,
             "ephemeral_storage": [],
@@ -242,54 +153,7 @@
             "requires_compatibilities": [
               "FARGATE"
             ],
-            "revision": 1,
-            "runtime_platform": [],
-            "skip_destroy": false,
-            "tags": {},
-            "tags_all": {},
-            "task_role_arn": "",
-            "track_latest": false,
-            "volume": []
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
-          "dependencies": [
-            "module.ecs.aws_iam_role.ecs_task_execution"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.ecs",
-      "mode": "managed",
-      "type": "aws_ecs_task_definition",
-      "name": "frontend",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
-            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest\",\"mountPoints\":[],\"name\":\"frontend\",\"portMappings\":[{\"containerPort\":80,\"hostPort\":80,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
-            "cpu": "256",
-            "enable_fault_injection": false,
-            "ephemeral_storage": [],
-            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
-            "family": "frontend-task",
-            "id": "frontend-task",
-            "inference_accelerator": [],
-            "ipc_mode": "",
-            "memory": "512",
-            "network_mode": "awsvpc",
-            "pid_mode": "",
-            "placement_constraints": [],
-            "proxy_configuration": [],
-            "requires_compatibilities": [
-              "FARGATE"
-            ],
-            "revision": 1,
+            "revision": 3,
             "runtime_platform": [],
             "skip_destroy": false,
             "tags": {},
@@ -482,6 +346,71 @@
     {
       "module": "module.network",
       "mode": "managed",
+      "type": "aws_acm_certificate",
+      "name": "cert",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"].us_east_1",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "certificate_authority_arn": "",
+            "certificate_body": null,
+            "certificate_chain": null,
+            "domain_name": "stock-analyzer.shrubb.ai",
+            "domain_validation_options": [
+              {
+                "domain_name": "stock-analyzer.shrubb.ai",
+                "resource_record_name": "_dc6ab177e18740b49a0fa48dc9d9ba85.stock-analyzer.shrubb.ai.",
+                "resource_record_type": "CNAME",
+                "resource_record_value": "_e68fc804ab950f50915a3adb4105d0f9.xlfgrmvvlj.acm-validations.aws."
+              }
+            ],
+            "early_renewal_duration": "",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "key_algorithm": "RSA_2048",
+            "not_after": "",
+            "not_before": "",
+            "options": [
+              {
+                "certificate_transparency_logging_preference": "ENABLED"
+              }
+            ],
+            "pending_renewal": false,
+            "private_key": null,
+            "renewal_eligibility": "INELIGIBLE",
+            "renewal_summary": [],
+            "status": "PENDING_VALIDATION",
+            "subject_alternative_names": [
+              "stock-analyzer.shrubb.ai"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-cert"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-cert"
+            },
+            "type": "AMAZON_ISSUED",
+            "validation_emails": [],
+            "validation_method": "DNS",
+            "validation_option": []
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "private_key"
+              }
+            ]
+          ],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
       "type": "aws_internet_gateway",
       "name": "gw",
       "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -658,7 +587,7 @@
             "routing_http_response_x_content_type_options_header_value": "",
             "routing_http_response_x_frame_options_header_value": "",
             "ssl_policy": "",
-            "tags": null,
+            "tags": {},
             "tags_all": {},
             "tcp_idle_timeout_seconds": null,
             "timeouts": null
@@ -668,126 +597,6 @@
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
           "dependencies": [
             "module.network.aws_lb.main",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_listener_rule",
-      "name": "backend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
-                "type": "forward"
-              }
-            ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
-            "condition": [
-              {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
-                  {
-                    "values": [
-                      "/predict"
-                    ]
-                  }
-                ],
-                "query_string": [],
-                "source_ip": []
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "priority": 101,
-            "tags": null,
-            "tags_all": {}
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.http",
-            "module.network.aws_lb_target_group.backend",
-            "module.network.aws_security_group.alb",
-            "module.network.aws_subnet.public",
-            "module.network.aws_vpc.main",
-            "module.network.data.aws_availability_zones.available"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_listener_rule",
-      "name": "frontend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "action": [
-              {
-                "authenticate_cognito": [],
-                "authenticate_oidc": [],
-                "fixed_response": [],
-                "forward": [],
-                "order": 1,
-                "redirect": [],
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-                "type": "forward"
-              }
-            ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
-            "condition": [
-              {
-                "host_header": [],
-                "http_header": [],
-                "http_request_method": [],
-                "path_pattern": [
-                  {
-                    "values": [
-                      "/"
-                    ]
-                  }
-                ],
-                "query_string": [],
-                "source_ip": []
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
-            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "priority": 100,
-            "tags": null,
-            "tags_all": {}
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_lb.main",
-            "module.network.aws_lb_listener.http",
-            "module.network.aws_lb_target_group.frontend",
             "module.network.aws_security_group.alb",
             "module.network.aws_subnet.public",
             "module.network.aws_vpc.main",
@@ -816,7 +625,7 @@
                 "healthy_threshold": 2,
                 "interval": 30,
                 "matcher": "200",
-                "path": "/predict",
+                "path": "/health",
                 "port": "traffic-port",
                 "protocol": "HTTP",
                 "timeout": 5,
@@ -833,98 +642,6 @@
             "name": "backend-tg",
             "name_prefix": "",
             "port": 8000,
-            "preserve_client_ip": null,
-            "protocol": "HTTP",
-            "protocol_version": "HTTP1",
-            "proxy_protocol_v2": false,
-            "slow_start": 0,
-            "stickiness": [
-              {
-                "cookie_duration": 86400,
-                "cookie_name": "",
-                "enabled": false,
-                "type": "lb_cookie"
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "target_failover": [
-              {
-                "on_deregistration": null,
-                "on_unhealthy": null
-              }
-            ],
-            "target_group_health": [
-              {
-                "dns_failover": [
-                  {
-                    "minimum_healthy_targets_count": "1",
-                    "minimum_healthy_targets_percentage": "off"
-                  }
-                ],
-                "unhealthy_state_routing": [
-                  {
-                    "minimum_healthy_targets_count": 1,
-                    "minimum_healthy_targets_percentage": "off"
-                  }
-                ]
-              }
-            ],
-            "target_health_state": [
-              {
-                "enable_unhealthy_connection_termination": null,
-                "unhealthy_draining_interval": null
-              }
-            ],
-            "target_type": "ip",
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
-          },
-          "sensitive_attributes": [],
-          "identity_schema_version": 0,
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.network.aws_vpc.main"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.network",
-      "mode": "managed",
-      "type": "aws_lb_target_group",
-      "name": "frontend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "arn_suffix": "targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "connection_termination": null,
-            "deregistration_delay": "300",
-            "health_check": [
-              {
-                "enabled": true,
-                "healthy_threshold": 2,
-                "interval": 30,
-                "matcher": "200",
-                "path": "/",
-                "port": "traffic-port",
-                "protocol": "HTTP",
-                "timeout": 5,
-                "unhealthy_threshold": 2
-              }
-            ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
-            "ip_address_type": "ipv4",
-            "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [],
-            "load_balancing_algorithm_type": "round_robin",
-            "load_balancing_anomaly_mitigation": "off",
-            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
-            "name": "frontend-tg",
-            "name_prefix": "",
-            "port": 80,
             "preserve_client_ip": null,
             "protocol": "HTTP",
             "protocol_version": "HTTP1",
@@ -1324,6 +1041,337 @@
           "sensitive_attributes": [],
           "identity_schema_version": 0,
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_cloudfront_distribution",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "aliases": [
+              "stock-analyzer.shrubb.ai"
+            ],
+            "arn": "arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0",
+            "caller_reference": "terraform-20250613165906122800000001",
+            "comment": null,
+            "continuous_deployment_policy_id": "",
+            "custom_error_response": [
+              {
+                "error_caching_min_ttl": 0,
+                "error_code": 404,
+                "response_code": 200,
+                "response_page_path": "/index.html"
+              }
+            ],
+            "default_cache_behavior": [
+              {
+                "allowed_methods": [
+                  "GET",
+                  "HEAD"
+                ],
+                "cache_policy_id": "",
+                "cached_methods": [
+                  "GET",
+                  "HEAD"
+                ],
+                "compress": false,
+                "default_ttl": 0,
+                "field_level_encryption_id": "",
+                "forwarded_values": [
+                  {
+                    "cookies": [
+                      {
+                        "forward": "none",
+                        "whitelisted_names": []
+                      }
+                    ],
+                    "headers": [],
+                    "query_string": false,
+                    "query_string_cache_keys": []
+                  }
+                ],
+                "function_association": [],
+                "grpc_config": [
+                  {
+                    "enabled": false
+                  }
+                ],
+                "lambda_function_association": [],
+                "max_ttl": 0,
+                "min_ttl": 0,
+                "origin_request_policy_id": "",
+                "realtime_log_config_arn": "",
+                "response_headers_policy_id": "",
+                "smooth_streaming": false,
+                "target_origin_id": "frontend-origin",
+                "trusted_key_groups": [],
+                "trusted_signers": [],
+                "viewer_protocol_policy": "redirect-to-https"
+              }
+            ],
+            "default_root_object": "index.html",
+            "domain_name": "d2g86i0wrkfe7n.cloudfront.net",
+            "enabled": true,
+            "etag": "EQAP9R7SKEFU4",
+            "hosted_zone_id": "Z2FDTNDATAQYW2",
+            "http_version": "http2",
+            "id": "E14Q29W1T4EPG0",
+            "in_progress_validation_batches": 0,
+            "is_ipv6_enabled": true,
+            "last_modified_time": "2025-06-13 17:34:15.562 +0000 UTC",
+            "logging_config": [],
+            "ordered_cache_behavior": [],
+            "origin": [
+              {
+                "connection_attempts": 3,
+                "connection_timeout": 10,
+                "custom_header": [],
+                "custom_origin_config": [],
+                "domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+                "origin_access_control_id": "EF0CVC5NFHZ5L",
+                "origin_id": "frontend-origin",
+                "origin_path": "",
+                "origin_shield": [],
+                "s3_origin_config": [],
+                "vpc_origin_config": []
+              }
+            ],
+            "origin_group": [],
+            "price_class": "PriceClass_All",
+            "restrictions": [
+              {
+                "geo_restriction": [
+                  {
+                    "locations": [],
+                    "restriction_type": "none"
+                  }
+                ]
+              }
+            ],
+            "retain_on_delete": false,
+            "staging": false,
+            "status": "Deployed",
+            "tags": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "tags_all": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "trusted_key_groups": [
+              {
+                "enabled": false,
+                "items": []
+              }
+            ],
+            "trusted_signers": [
+              {
+                "enabled": false,
+                "items": []
+              }
+            ],
+            "viewer_certificate": [
+              {
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+                "cloudfront_default_certificate": false,
+                "iam_certificate_id": "",
+                "minimum_protocol_version": "TLSv1.2_2021",
+                "ssl_support_method": "sni-only"
+              }
+            ],
+            "wait_for_deployment": true,
+            "web_acl_id": ""
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_cloudfront_origin_access_control",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/EF0CVC5NFHZ5L",
+            "description": "OAC for S3 frontend",
+            "etag": "ETVPDKIKX0DER",
+            "id": "EF0CVC5NFHZ5L",
+            "name": "frontend-oac",
+            "origin_access_control_origin_type": "s3",
+            "signing_behavior": "always",
+            "signing_protocol": "sigv4"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "bucket_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": true,
+            "grant": [
+              {
+                "id": "cc7ec2d396e31a7d8694c7b01281c323af23ae26a419de041c3bbabb7f36df65",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z2O1EMRO9K5GLX",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-east-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "tags_all": {
+              "Env": "prod",
+              "Project": "StockAnalyzer"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [
+              {
+                "error_document": "index.html",
+                "index_document": "index.html",
+                "redirect_all_requests_to": "",
+                "routing_rules": ""
+              }
+            ],
+            "website_domain": "s3-website.us-east-2.amazonaws.com",
+            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
+      "type": "aws_s3_bucket_website_configuration",
+      "name": "frontend",
+      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "error_document": [
+              {
+                "key": "index.html"
+              }
+            ],
+            "expected_bucket_owner": "",
+            "id": "shrubb-ai-stock-analyzer-frontend",
+            "index_document": [
+              {
+                "suffix": "index.html"
+              }
+            ],
+            "redirect_all_requests_to": [],
+            "routing_rule": [],
+            "routing_rules": "",
+            "website_domain": "s3-website.us-east-2.amazonaws.com",
+            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
         }
       ]
     }

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,8 +1,8 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 72,
-  "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
+  "serial": 41,
+  "lineage": "502feed0-8c80-a89e-54b6-eae94b4ea6d0",
   "outputs": {},
   "resources": [
     {
@@ -15,9 +15,9 @@
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "arn": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "configuration": [],
-            "id": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "id": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "name": "stock-analyzer-cluster",
             "service_connect_defaults": [],
             "setting": [
@@ -48,7 +48,7 @@
             "alarms": [],
             "availability_zone_rebalancing": "DISABLED",
             "capacity_provider_strategy": [],
-            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "cluster": "arn:aws:ecs:us-east-1:896924684176:cluster/stock-analyzer-cluster",
             "deployment_circuit_breaker": [
               {
                 "enable": false,
@@ -69,14 +69,14 @@
             "force_new_deployment": null,
             "health_check_grace_period_seconds": 0,
             "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
-            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/backend-service",
+            "id": "arn:aws:ecs:us-east-1:896924684176:service/stock-analyzer-cluster/backend-service",
             "launch_type": "FARGATE",
             "load_balancer": [
               {
                 "container_name": "backend",
                 "container_port": 8000,
                 "elb_name": "",
-                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db"
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6"
               }
             ],
             "name": "backend-service",
@@ -84,11 +84,11 @@
               {
                 "assign_public_ip": true,
                 "security_groups": [
-                  "sg-042b54e04d09d4588"
+                  "sg-0aee182cece4a11e9"
                 ],
                 "subnets": [
-                  "subnet-0a2b4b43925401a30",
-                  "subnet-0c3b58546b6dff7dd"
+                  "subnet-0043925f401046cda",
+                  "subnet-0f100907225ebc945"
                 ]
               }
             ],
@@ -101,7 +101,7 @@
             "service_registries": [],
             "tags": {},
             "tags_all": {},
-            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
+            "task_definition": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:1",
             "timeouts": null,
             "triggers": {},
             "volume_configuration": [],
@@ -134,9 +134,9 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:3",
-            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
-            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:v0.0.2\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "arn": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task:1",
+            "arn_without_revision": "arn:aws:ecs:us-east-1:896924684176:task-definition/backend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-1.amazonaws.com/stock-analyzer-backend:v0.0.1\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
             "cpu": "256",
             "enable_fault_injection": false,
             "ephemeral_storage": [],
@@ -153,7 +153,7 @@
             "requires_compatibilities": [
               "FARGATE"
             ],
-            "revision": 3,
+            "revision": 1,
             "runtime_platform": [],
             "skip_destroy": false,
             "tags": {},
@@ -183,7 +183,7 @@
           "attributes": {
             "arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
             "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
-            "create_date": "2025-06-12T16:45:38Z",
+            "create_date": "2025-06-16T16:04:43Z",
             "description": "",
             "force_detach_policies": false,
             "id": "ecsTaskExecutionRole",
@@ -198,7 +198,7 @@
             "permissions_boundary": "",
             "tags": {},
             "tags_all": {},
-            "unique_id": "AROA5BVHAR6IEKMAKZELH"
+            "unique_id": "AROA5BVHAR6IPGSL6T44V"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -216,7 +216,7 @@
         {
           "schema_version": 0,
           "attributes": {
-            "id": "ecsTaskExecutionRole-20250612164537129100000001",
+            "id": "ecsTaskExecutionRole-20250616160442567800000002",
             "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
             "role": "ecsTaskExecutionRole"
           },
@@ -239,7 +239,7 @@
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-042b54e04d09d4588",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:security-group/sg-0aee182cece4a11e9",
             "description": "Allow traffic from ALB to ECS tasks",
             "egress": [
               {
@@ -256,7 +256,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-042b54e04d09d4588",
+            "id": "sg-0aee182cece4a11e9",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -296,7 +296,7 @@
               "Name": "ecs-tasks-sg"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -312,7 +312,7 @@
       "mode": "data",
       "type": "aws_availability_zones",
       "name": "available",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -322,20 +322,26 @@
             "exclude_zone_ids": null,
             "filter": null,
             "group_names": [
-              "us-east-2-zg-1"
+              "us-east-1-zg-1"
             ],
-            "id": "us-east-2",
+            "id": "us-east-1",
             "names": [
-              "us-east-2a",
-              "us-east-2b",
-              "us-east-2c"
+              "us-east-1a",
+              "us-east-1b",
+              "us-east-1c",
+              "us-east-1d",
+              "us-east-1e",
+              "us-east-1f"
             ],
             "state": null,
             "timeouts": null,
             "zone_ids": [
-              "use2-az1",
-              "use2-az2",
-              "use2-az3"
+              "use1-az4",
+              "use1-az6",
+              "use1-az1",
+              "use1-az2",
+              "use1-az3",
+              "use1-az5"
             ]
           },
           "sensitive_attributes": [],
@@ -348,12 +354,12 @@
       "mode": "managed",
       "type": "aws_acm_certificate",
       "name": "cert",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"].us_east_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "certificate_authority_arn": "",
             "certificate_body": null,
             "certificate_chain": null,
@@ -367,10 +373,10 @@
               }
             ],
             "early_renewal_duration": "",
-            "id": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+            "id": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "key_algorithm": "RSA_2048",
-            "not_after": "",
-            "not_before": "",
+            "not_after": "2026-07-15T23:59:59Z",
+            "not_before": "2025-06-16T00:00:00Z",
             "options": [
               {
                 "certificate_transparency_logging_preference": "ENABLED"
@@ -378,9 +384,9 @@
             ],
             "pending_renewal": false,
             "private_key": null,
-            "renewal_eligibility": "INELIGIBLE",
+            "renewal_eligibility": "ELIGIBLE",
             "renewal_summary": [],
-            "status": "PENDING_VALIDATION",
+            "status": "ISSUED",
             "subject_alternative_names": [
               "stock-analyzer.shrubb.ai"
             ],
@@ -413,18 +419,18 @@
       "mode": "managed",
       "type": "aws_internet_gateway",
       "name": "gw",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:internet-gateway/igw-0fa0bc93b789a7643",
-            "id": "igw-0fa0bc93b789a7643",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:internet-gateway/igw-0d11b3068dad9d031",
+            "id": "igw-0d11b3068dad9d031",
             "owner_id": "896924684176",
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -440,7 +446,7 @@
       "mode": "managed",
       "type": "aws_lb",
       "name": "main",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -452,8 +458,8 @@
                 "prefix": ""
               }
             ],
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
-            "arn_suffix": "app/stock-analyzer-alb/f81c590316270958",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
+            "arn_suffix": "app/stock-analyzer-alb/b093953306bc1430",
             "client_keep_alive": 3600,
             "connection_logs": [
               {
@@ -464,7 +470,7 @@
             ],
             "customer_owned_ipv4_pool": "",
             "desync_mitigation_mode": "defensive",
-            "dns_name": "stock-analyzer-alb-1551012673.us-east-2.elb.amazonaws.com",
+            "dns_name": "stock-analyzer-alb-1625738139.us-east-1.elb.amazonaws.com",
             "dns_record_client_routing_policy": null,
             "drop_invalid_header_fields": false,
             "enable_cross_zone_load_balancing": true,
@@ -475,7 +481,7 @@
             "enable_xff_client_port": false,
             "enable_zonal_shift": false,
             "enforce_security_group_inbound_rules_on_private_link_traffic": "",
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
             "idle_timeout": 60,
             "internal": false,
             "ip_address_type": "ipv4",
@@ -486,7 +492,7 @@
             "name_prefix": "",
             "preserve_host_header": false,
             "security_groups": [
-              "sg-0849043bdcac304cd"
+              "sg-0e35606b1c6fb04c3"
             ],
             "subnet_mapping": [
               {
@@ -494,19 +500,19 @@
                 "ipv6_address": "",
                 "outpost_id": "",
                 "private_ipv4_address": "",
-                "subnet_id": "subnet-0a2b4b43925401a30"
+                "subnet_id": "subnet-0043925f401046cda"
               },
               {
                 "allocation_id": "",
                 "ipv6_address": "",
                 "outpost_id": "",
                 "private_ipv4_address": "",
-                "subnet_id": "subnet-0c3b58546b6dff7dd"
+                "subnet_id": "subnet-0f100907225ebc945"
               }
             ],
             "subnets": [
-              "subnet-0a2b4b43925401a30",
-              "subnet-0c3b58546b6dff7dd"
+              "subnet-0043925f401046cda",
+              "subnet-0f100907225ebc945"
             ],
             "tags": {
               "Name": "stock-analyzer-alb"
@@ -515,9 +521,9 @@
               "Name": "stock-analyzer-alb"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a",
+            "vpc_id": "vpc-0997b90c9d647d6e2",
             "xff_header_processing_mode": "append",
-            "zone_id": "Z3AADJGX6KTTL2"
+            "zone_id": "Z35SXDOTRQ7X7K"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -535,15 +541,15 @@
       "module": "module.network",
       "mode": "managed",
       "type": "aws_lb_listener",
-      "name": "http",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "name": "https",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "alpn_policy": null,
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "certificate_arn": null,
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
             "default_action": [
               {
                 "authenticate_cognito": [],
@@ -551,7 +557,7 @@
                 "fixed_response": [
                   {
                     "content_type": "text/plain",
-                    "message_body": "Default backend reached",
+                    "message_body": "Not found",
                     "status_code": "404"
                   }
                 ],
@@ -562,19 +568,26 @@
                 "type": "fixed-response"
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
-            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
-            "mutual_authentication": [],
-            "port": 80,
-            "protocol": "HTTP",
-            "routing_http_request_x_amzn_mtls_clientcert_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": null,
-            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": null,
-            "routing_http_request_x_amzn_tls_cipher_suite_header_name": null,
-            "routing_http_request_x_amzn_tls_version_header_name": null,
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430",
+            "mutual_authentication": [
+              {
+                "advertise_trust_store_ca_names": "",
+                "ignore_client_certificate_expiry": false,
+                "mode": "off",
+                "trust_store_arn": ""
+              }
+            ],
+            "port": 443,
+            "protocol": "HTTPS",
+            "routing_http_request_x_amzn_mtls_clientcert_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": "",
+            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": "",
+            "routing_http_request_x_amzn_tls_cipher_suite_header_name": "",
+            "routing_http_request_x_amzn_tls_version_header_name": "",
             "routing_http_response_access_control_allow_credentials_header_value": "",
             "routing_http_response_access_control_allow_headers_header_value": "",
             "routing_http_response_access_control_allow_methods_header_value": "",
@@ -586,7 +599,7 @@
             "routing_http_response_strict_transport_security_header_value": "",
             "routing_http_response_x_content_type_options_header_value": "",
             "routing_http_response_x_frame_options_header_value": "",
-            "ssl_policy": "",
+            "ssl_policy": "ELBSecurityPolicy-2016-08",
             "tags": {},
             "tags_all": {},
             "tcp_idle_timeout_seconds": null,
@@ -596,7 +609,69 @@
           "identity_schema_version": 0,
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
           "dependencies": [
+            "module.network.aws_acm_certificate.cert",
             "module.network.aws_lb.main",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "api_routing",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/api/*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener-rule/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b/e60ccbd760043500",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:listener/app/stock-analyzer-alb/b093953306bc1430/d2892f4bd8991b7b",
+            "priority": 20,
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.https",
+            "module.network.aws_lb_target_group.backend",
             "module.network.aws_security_group.alb",
             "module.network.aws_subnet.public",
             "module.network.aws_vpc.main",
@@ -610,13 +685,13 @@
       "mode": "managed",
       "type": "aws_lb_target_group",
       "name": "backend",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
-            "arn_suffix": "targetgroup/backend-tg/4bb7268be23e80db",
+            "arn": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
+            "arn_suffix": "targetgroup/backend-tg/1056eddac5e222d6",
             "connection_termination": null,
             "deregistration_delay": "300",
             "health_check": [
@@ -632,10 +707,12 @@
                 "unhealthy_threshold": 2
               }
             ],
-            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "id": "arn:aws:elasticloadbalancing:us-east-1:896924684176:targetgroup/backend-tg/1056eddac5e222d6",
             "ip_address_type": "ipv4",
             "lambda_multi_value_headers_enabled": false,
-            "load_balancer_arns": [],
+            "load_balancer_arns": [
+              "arn:aws:elasticloadbalancing:us-east-1:896924684176:loadbalancer/app/stock-analyzer-alb/b093953306bc1430"
+            ],
             "load_balancing_algorithm_type": "round_robin",
             "load_balancing_anomaly_mitigation": "off",
             "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
@@ -686,7 +763,7 @@
               }
             ],
             "target_type": "ip",
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -702,7 +779,7 @@
       "mode": "managed",
       "type": "aws_route",
       "name": "internet_access",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -713,15 +790,15 @@
             "destination_ipv6_cidr_block": "",
             "destination_prefix_list_id": "",
             "egress_only_gateway_id": "",
-            "gateway_id": "igw-0fa0bc93b789a7643",
-            "id": "r-rtb-0c3bad089d9c13adc1080289494",
+            "gateway_id": "igw-0d11b3068dad9d031",
+            "id": "r-rtb-034d9c8732eb26e0f1080289494",
             "instance_id": "",
             "instance_owner_id": "",
             "local_gateway_id": "",
             "nat_gateway_id": "",
             "network_interface_id": "",
             "origin": "CreateRoute",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
             "state": "active",
             "timeouts": null,
             "transit_gateway_id": "",
@@ -744,13 +821,13 @@
       "mode": "managed",
       "type": "aws_route_table",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:route-table/rtb-0c3bad089d9c13adc",
-            "id": "rtb-0c3bad089d9c13adc",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:route-table/rtb-034d9c8732eb26e0f",
+            "id": "rtb-034d9c8732eb26e0f",
             "owner_id": "896924684176",
             "propagating_vgws": [],
             "route": [
@@ -760,7 +837,7 @@
                 "core_network_arn": "",
                 "destination_prefix_list_id": "",
                 "egress_only_gateway_id": "",
-                "gateway_id": "igw-0fa0bc93b789a7643",
+                "gateway_id": "igw-0d11b3068dad9d031",
                 "ipv6_cidr_block": "",
                 "local_gateway_id": "",
                 "nat_gateway_id": "",
@@ -773,7 +850,7 @@
             "tags": {},
             "tags_all": {},
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -789,16 +866,16 @@
       "mode": "managed",
       "type": "aws_route_table_association",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "index_key": 0,
           "schema_version": 0,
           "attributes": {
             "gateway_id": "",
-            "id": "rtbassoc-0644356cbf9fcd16a",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
-            "subnet_id": "subnet-0a2b4b43925401a30",
+            "id": "rtbassoc-0a6019f8929054f92",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
+            "subnet_id": "subnet-0043925f401046cda",
             "timeouts": null
           },
           "sensitive_attributes": [],
@@ -816,9 +893,9 @@
           "schema_version": 0,
           "attributes": {
             "gateway_id": "",
-            "id": "rtbassoc-061959307ae8430b0",
-            "route_table_id": "rtb-0c3bad089d9c13adc",
-            "subnet_id": "subnet-0c3b58546b6dff7dd",
+            "id": "rtbassoc-0eea9c0ead828fbb8",
+            "route_table_id": "rtb-034d9c8732eb26e0f",
+            "subnet_id": "subnet-0f100907225ebc945",
             "timeouts": null
           },
           "sensitive_attributes": [],
@@ -838,12 +915,12 @@
       "mode": "managed",
       "type": "aws_security_group",
       "name": "alb",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-0849043bdcac304cd",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:security-group/sg-0e35606b1c6fb04c3",
             "description": "Allow HTTP/HTTPS inbound traffic",
             "egress": [
               {
@@ -860,7 +937,7 @@
                 "to_port": 0
               }
             ],
-            "id": "sg-0849043bdcac304cd",
+            "id": "sg-0e35606b1c6fb04c3",
             "ingress": [
               {
                 "cidr_blocks": [
@@ -900,7 +977,7 @@
               "Name": "alb-sg"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -916,23 +993,23 @@
       "mode": "managed",
       "type": "aws_subnet",
       "name": "public",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "index_key": 0,
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0a2b4b43925401a30",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:subnet/subnet-0043925f401046cda",
             "assign_ipv6_address_on_creation": false,
-            "availability_zone": "us-east-2a",
-            "availability_zone_id": "use2-az1",
+            "availability_zone": "us-east-1a",
+            "availability_zone_id": "use1-az4",
             "cidr_block": "10.0.0.0/20",
             "customer_owned_ipv4_pool": "",
             "enable_dns64": false,
             "enable_lni_at_device_index": 0,
             "enable_resource_name_dns_a_record_on_launch": false,
             "enable_resource_name_dns_aaaa_record_on_launch": false,
-            "id": "subnet-0a2b4b43925401a30",
+            "id": "subnet-0043925f401046cda",
             "ipv6_cidr_block": "",
             "ipv6_cidr_block_association_id": "",
             "ipv6_native": false,
@@ -948,7 +1025,7 @@
               "Name": "stock-public-0"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -962,17 +1039,17 @@
           "index_key": 1,
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0c3b58546b6dff7dd",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:subnet/subnet-0f100907225ebc945",
             "assign_ipv6_address_on_creation": false,
-            "availability_zone": "us-east-2b",
-            "availability_zone_id": "use2-az2",
+            "availability_zone": "us-east-1b",
+            "availability_zone_id": "use1-az6",
             "cidr_block": "10.0.16.0/20",
             "customer_owned_ipv4_pool": "",
             "enable_dns64": false,
             "enable_lni_at_device_index": 0,
             "enable_resource_name_dns_a_record_on_launch": false,
             "enable_resource_name_dns_aaaa_record_on_launch": false,
-            "id": "subnet-0c3b58546b6dff7dd",
+            "id": "subnet-0f100907225ebc945",
             "ipv6_cidr_block": "",
             "ipv6_cidr_block_association_id": "",
             "ipv6_native": false,
@@ -988,7 +1065,7 @@
               "Name": "stock-public-1"
             },
             "timeouts": null,
-            "vpc_id": "vpc-0e677828b4dc5fa9a"
+            "vpc_id": "vpc-0997b90c9d647d6e2"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1005,22 +1082,22 @@
       "mode": "managed",
       "type": "aws_vpc",
       "name": "main",
-      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
           "attributes": {
-            "arn": "arn:aws:ec2:us-east-2:896924684176:vpc/vpc-0e677828b4dc5fa9a",
+            "arn": "arn:aws:ec2:us-east-1:896924684176:vpc/vpc-0997b90c9d647d6e2",
             "assign_generated_ipv6_cidr_block": false,
             "cidr_block": "10.0.0.0/16",
-            "default_network_acl_id": "acl-0686f8d4be1e2c8dc",
-            "default_route_table_id": "rtb-0509e12dac3222b5d",
-            "default_security_group_id": "sg-010ecb86c454dda99",
-            "dhcp_options_id": "dopt-08834e4367484cb08",
+            "default_network_acl_id": "acl-0a373b2c9d432f23a",
+            "default_route_table_id": "rtb-028eb59674d07acfc",
+            "default_security_group_id": "sg-0e7df595b1881bc74",
+            "dhcp_options_id": "dopt-0b60817d35a8d54da",
             "enable_dns_hostnames": true,
             "enable_dns_support": true,
             "enable_network_address_usage_metrics": false,
-            "id": "vpc-0e677828b4dc5fa9a",
+            "id": "vpc-0997b90c9d647d6e2",
             "instance_tenancy": "default",
             "ipv4_ipam_pool_id": null,
             "ipv4_netmask_length": null,
@@ -1029,7 +1106,7 @@
             "ipv6_cidr_block_network_border_group": "",
             "ipv6_ipam_pool_id": "",
             "ipv6_netmask_length": 0,
-            "main_route_table_id": "rtb-0509e12dac3222b5d",
+            "main_route_table_id": "rtb-028eb59674d07acfc",
             "owner_id": "896924684176",
             "tags": {
               "Name": "stock-vpc"
@@ -1049,7 +1126,7 @@
       "mode": "managed",
       "type": "aws_cloudfront_distribution",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
@@ -1057,13 +1134,13 @@
             "aliases": [
               "stock-analyzer.shrubb.ai"
             ],
-            "arn": "arn:aws:cloudfront::896924684176:distribution/E14Q29W1T4EPG0",
-            "caller_reference": "terraform-20250613165906122800000001",
+            "arn": "arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33",
+            "caller_reference": "terraform-20250616164118108800000001",
             "comment": null,
             "continuous_deployment_policy_id": "",
             "custom_error_response": [
               {
-                "error_caching_min_ttl": 0,
+                "error_caching_min_ttl": null,
                 "error_code": 404,
                 "response_code": 200,
                 "response_page_path": "/index.html"
@@ -1116,15 +1193,15 @@
               }
             ],
             "default_root_object": "index.html",
-            "domain_name": "d2g86i0wrkfe7n.cloudfront.net",
+            "domain_name": "dxoccp6gw8qk3.cloudfront.net",
             "enabled": true,
-            "etag": "EQAP9R7SKEFU4",
+            "etag": "E1N0T1754BGVZW",
             "hosted_zone_id": "Z2FDTNDATAQYW2",
             "http_version": "http2",
-            "id": "E14Q29W1T4EPG0",
+            "id": "E3R6TRBTP0FQ33",
             "in_progress_validation_batches": 0,
             "is_ipv6_enabled": true,
-            "last_modified_time": "2025-06-13 17:34:15.562 +0000 UTC",
+            "last_modified_time": "2025-06-16 16:41:19.633 +0000 UTC",
             "logging_config": [],
             "ordered_cache_behavior": [],
             "origin": [
@@ -1133,8 +1210,8 @@
                 "connection_timeout": 10,
                 "custom_header": [],
                 "custom_origin_config": [],
-                "domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
-                "origin_access_control_id": "EF0CVC5NFHZ5L",
+                "domain_name": "shrubb-stock-analyzer-frontend.s3.us-east-1.amazonaws.com",
+                "origin_access_control_id": "E2RNKCR1QR7DXH",
                 "origin_id": "frontend-origin",
                 "origin_path": "",
                 "origin_shield": [],
@@ -1179,7 +1256,7 @@
             ],
             "viewer_certificate": [
               {
-                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/7461e660-ca9b-4829-b843-74d3e7276087",
+                "acm_certificate_arn": "arn:aws:acm:us-east-1:896924684176:certificate/6c39e5cd-7f31-49c1-bccd-e77d8e41176e",
                 "cloudfront_default_certificate": false,
                 "iam_certificate_id": "",
                 "minimum_protocol_version": "TLSv1.2_2021",
@@ -1205,15 +1282,15 @@
       "mode": "managed",
       "type": "aws_cloudfront_origin_access_control",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/EF0CVC5NFHZ5L",
+            "arn": "arn:aws:cloudfront::896924684176:origin-access-control/E2RNKCR1QR7DXH",
             "description": "OAC for S3 frontend",
             "etag": "ETVPDKIKX0DER",
-            "id": "EF0CVC5NFHZ5L",
+            "id": "E2RNKCR1QR7DXH",
             "name": "frontend-oac",
             "origin_access_control_origin_type": "s3",
             "signing_behavior": "always",
@@ -1230,18 +1307,18 @@
       "mode": "managed",
       "type": "aws_s3_bucket",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "acceleration_status": "",
             "acl": null,
-            "arn": "arn:aws:s3:::shrubb-ai-stock-analyzer-frontend",
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
-            "bucket_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.amazonaws.com",
+            "arn": "arn:aws:s3:::shrubb-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "bucket_domain_name": "shrubb-stock-analyzer-frontend.s3.amazonaws.com",
             "bucket_prefix": "",
-            "bucket_regional_domain_name": "shrubb-ai-stock-analyzer-frontend.s3.us-east-2.amazonaws.com",
+            "bucket_regional_domain_name": "shrubb-stock-analyzer-frontend.s3.us-east-1.amazonaws.com",
             "cors_rule": [],
             "force_destroy": true,
             "grant": [
@@ -1254,14 +1331,14 @@
                 "uri": ""
               }
             ],
-            "hosted_zone_id": "Z2O1EMRO9K5GLX",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "hosted_zone_id": "Z3AQBSTGFYJSTF",
+            "id": "shrubb-stock-analyzer-frontend",
             "lifecycle_rule": [],
             "logging": [],
             "object_lock_configuration": [],
             "object_lock_enabled": false,
             "policy": "",
-            "region": "us-east-2",
+            "region": "us-east-1",
             "replication_configuration": [],
             "request_payer": "BucketOwner",
             "server_side_encryption_configuration": [
@@ -1294,16 +1371,9 @@
                 "mfa_delete": false
               }
             ],
-            "website": [
-              {
-                "error_document": "index.html",
-                "index_document": "index.html",
-                "redirect_all_requests_to": "",
-                "routing_rules": ""
-              }
-            ],
-            "website_domain": "s3-website.us-east-2.amazonaws.com",
-            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,
@@ -1314,17 +1384,43 @@
     {
       "module": "module.s3cloudfront",
       "mode": "managed",
+      "type": "aws_s3_bucket_policy",
+      "name": "frontend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
+            "policy": "{\"Statement\":[{\"Action\":\"s3:GetObject\",\"Condition\":{\"StringEquals\":{\"AWS:SourceArn\":\"arn:aws:cloudfront::896924684176:distribution/E3R6TRBTP0FQ33\"}},\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudfront.amazonaws.com\"},\"Resource\":\"arn:aws:s3:::shrubb-stock-analyzer-frontend/*\"}],\"Version\":\"2012-10-17\"}"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_acm_certificate.cert",
+            "module.s3cloudfront.aws_cloudfront_distribution.frontend",
+            "module.s3cloudfront.aws_cloudfront_origin_access_control.frontend",
+            "module.s3cloudfront.aws_s3_bucket.frontend"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.s3cloudfront",
+      "mode": "managed",
       "type": "aws_s3_bucket_public_access_block",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "block_public_acls": true,
             "block_public_policy": true,
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
             "ignore_public_acls": true,
             "restrict_public_buckets": true
           },
@@ -1342,19 +1438,19 @@
       "mode": "managed",
       "type": "aws_s3_bucket_website_configuration",
       "name": "frontend",
-      "provider": "module.s3cloudfront.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
-            "bucket": "shrubb-ai-stock-analyzer-frontend",
+            "bucket": "shrubb-stock-analyzer-frontend",
             "error_document": [
               {
                 "key": "index.html"
               }
             ],
             "expected_bucket_owner": "",
-            "id": "shrubb-ai-stock-analyzer-frontend",
+            "id": "shrubb-stock-analyzer-frontend",
             "index_document": [
               {
                 "suffix": "index.html"
@@ -1363,8 +1459,8 @@
             "redirect_all_requests_to": [],
             "routing_rule": [],
             "routing_rules": "",
-            "website_domain": "s3-website.us-east-2.amazonaws.com",
-            "website_endpoint": "shrubb-ai-stock-analyzer-frontend.s3-website.us-east-2.amazonaws.com"
+            "website_domain": "s3-website-us-east-1.amazonaws.com",
+            "website_endpoint": "shrubb-stock-analyzer-frontend.s3-website-us-east-1.amazonaws.com"
           },
           "sensitive_attributes": [],
           "identity_schema_version": 0,

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,0 +1,1332 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 31,
+  "lineage": "b4023ab8-e0b0-93b5-00a6-5b137d960c82",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_cluster",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "configuration": [],
+            "id": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "name": "stock-analyzer-cluster",
+            "service_connect_defaults": [],
+            "setting": [
+              {
+                "name": "containerInsights",
+                "value": "disabled"
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "alarms": [],
+            "availability_zone_rebalancing": "DISABLED",
+            "capacity_provider_strategy": [],
+            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [
+              {
+                "type": "ECS"
+              }
+            ],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 100,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": null,
+            "health_check_grace_period_seconds": 0,
+            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/backend-service",
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "container_name": "backend",
+                "container_port": 8000,
+                "elb_name": "",
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db"
+              }
+            ],
+            "name": "backend-service",
+            "network_configuration": [
+              {
+                "assign_public_ip": true,
+                "security_groups": [
+                  "sg-042b54e04d09d4588"
+                ],
+                "subnets": [
+                  "subnet-0a2b4b43925401a30",
+                  "subnet-0c3b58546b6dff7dd"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "platform_version": "LATEST",
+            "propagate_tags": "NONE",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [],
+            "service_registries": [],
+            "tags": null,
+            "tags_all": {},
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "timeouts": null,
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": false
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.ecs.aws_ecs_cluster.main",
+            "module.ecs.aws_ecs_task_definition.backend",
+            "module.ecs.aws_iam_role.ecs_task_execution",
+            "module.ecs.aws_security_group.ecs_tasks",
+            "module.network.aws_lb_target_group.backend",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "frontend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "alarms": [],
+            "availability_zone_rebalancing": "DISABLED",
+            "capacity_provider_strategy": [],
+            "cluster": "arn:aws:ecs:us-east-2:896924684176:cluster/stock-analyzer-cluster",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [
+              {
+                "type": "ECS"
+              }
+            ],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 100,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": null,
+            "health_check_grace_period_seconds": 0,
+            "iam_role": "/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+            "id": "arn:aws:ecs:us-east-2:896924684176:service/stock-analyzer-cluster/frontend-service",
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "container_name": "frontend",
+                "container_port": 80,
+                "elb_name": "",
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4"
+              }
+            ],
+            "name": "frontend-service",
+            "network_configuration": [
+              {
+                "assign_public_ip": true,
+                "security_groups": [
+                  "sg-042b54e04d09d4588"
+                ],
+                "subnets": [
+                  "subnet-0a2b4b43925401a30",
+                  "subnet-0c3b58546b6dff7dd"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "platform_version": "LATEST",
+            "propagate_tags": "NONE",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [],
+            "service_registries": [],
+            "tags": null,
+            "tags_all": {},
+            "task_definition": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
+            "timeouts": null,
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": false
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.ecs.aws_ecs_cluster.main",
+            "module.ecs.aws_ecs_task_definition.frontend",
+            "module.ecs.aws_iam_role.ecs_task_execution",
+            "module.ecs.aws_security_group.ecs_tasks",
+            "module.network.aws_lb_target_group.frontend",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task:1",
+            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/backend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-backend:latest\",\"mountPoints\":[],\"name\":\"backend\",\"portMappings\":[{\"containerPort\":8000,\"hostPort\":8000,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "cpu": "256",
+            "enable_fault_injection": false,
+            "ephemeral_storage": [],
+            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "family": "backend-task",
+            "id": "backend-task",
+            "inference_accelerator": [],
+            "ipc_mode": "",
+            "memory": "512",
+            "network_mode": "awsvpc",
+            "pid_mode": "",
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "revision": 1,
+            "runtime_platform": [],
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {},
+            "task_role_arn": "",
+            "track_latest": false,
+            "volume": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "frontend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task:1",
+            "arn_without_revision": "arn:aws:ecs:us-east-2:896924684176:task-definition/frontend-task",
+            "container_definitions": "[{\"environment\":[],\"essential\":true,\"image\":\"896924684176.dkr.ecr.us-east-2.amazonaws.com/stock-analyzer-frontend:latest\",\"mountPoints\":[],\"name\":\"frontend\",\"portMappings\":[{\"containerPort\":80,\"hostPort\":80,\"protocol\":\"tcp\"}],\"systemControls\":[],\"volumesFrom\":[]}]",
+            "cpu": "256",
+            "enable_fault_injection": false,
+            "ephemeral_storage": [],
+            "execution_role_arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "family": "frontend-task",
+            "id": "frontend-task",
+            "inference_accelerator": [],
+            "ipc_mode": "",
+            "memory": "512",
+            "network_mode": "awsvpc",
+            "pid_mode": "",
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "revision": 1,
+            "runtime_platform": [],
+            "skip_destroy": false,
+            "tags": {},
+            "tags_all": {},
+            "task_role_arn": "",
+            "track_latest": false,
+            "volume": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "ecs_task_execution",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::896924684176:role/ecsTaskExecutionRole",
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "create_date": "2025-06-12T16:45:38Z",
+            "description": "",
+            "force_detach_policies": false,
+            "id": "ecsTaskExecutionRole",
+            "inline_policy": [],
+            "managed_policy_arns": [
+              "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+            ],
+            "max_session_duration": 3600,
+            "name": "ecsTaskExecutionRole",
+            "name_prefix": "",
+            "path": "/",
+            "permissions_boundary": "",
+            "tags": {},
+            "tags_all": {},
+            "unique_id": "AROA5BVHAR6IEKMAKZELH"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_iam_role_policy_attachment",
+      "name": "ecs_execution_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "ecsTaskExecutionRole-20250612164537129100000001",
+            "policy_arn": "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+            "role": "ecsTaskExecutionRole"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.ecs.aws_iam_role.ecs_task_execution"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.ecs",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "ecs_tasks",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-042b54e04d09d4588",
+            "description": "Allow traffic from ALB to ECS tasks",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-042b54e04d09d4588",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 8000,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 8000
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "ecs-tasks-sg",
+            "name_prefix": "",
+            "owner_id": "896924684176",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "ecs-tasks-sg"
+            },
+            "tags_all": {
+              "Name": "ecs-tasks-sg"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "data",
+      "type": "aws_availability_zones",
+      "name": "available",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "all_availability_zones": null,
+            "exclude_names": null,
+            "exclude_zone_ids": null,
+            "filter": null,
+            "group_names": [
+              "us-east-2-zg-1"
+            ],
+            "id": "us-east-2",
+            "names": [
+              "us-east-2a",
+              "us-east-2b",
+              "us-east-2c"
+            ],
+            "state": null,
+            "timeouts": null,
+            "zone_ids": [
+              "use2-az1",
+              "use2-az2",
+              "use2-az3"
+            ]
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "gw",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:internet-gateway/igw-0fa0bc93b789a7643",
+            "id": "igw-0fa0bc93b789a7643",
+            "owner_id": "896924684176",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb",
+      "name": "main",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_logs": [
+              {
+                "bucket": "",
+                "enabled": false,
+                "prefix": ""
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "arn_suffix": "app/stock-analyzer-alb/f81c590316270958",
+            "client_keep_alive": 3600,
+            "connection_logs": [
+              {
+                "bucket": "",
+                "enabled": false,
+                "prefix": ""
+              }
+            ],
+            "customer_owned_ipv4_pool": "",
+            "desync_mitigation_mode": "defensive",
+            "dns_name": "stock-analyzer-alb-1551012673.us-east-2.elb.amazonaws.com",
+            "dns_record_client_routing_policy": null,
+            "drop_invalid_header_fields": false,
+            "enable_cross_zone_load_balancing": true,
+            "enable_deletion_protection": false,
+            "enable_http2": true,
+            "enable_tls_version_and_cipher_suite_headers": false,
+            "enable_waf_fail_open": false,
+            "enable_xff_client_port": false,
+            "enable_zonal_shift": false,
+            "enforce_security_group_inbound_rules_on_private_link_traffic": "",
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "idle_timeout": 60,
+            "internal": false,
+            "ip_address_type": "ipv4",
+            "ipam_pools": [],
+            "load_balancer_type": "application",
+            "minimum_load_balancer_capacity": [],
+            "name": "stock-analyzer-alb",
+            "name_prefix": "",
+            "preserve_host_header": false,
+            "security_groups": [
+              "sg-0849043bdcac304cd"
+            ],
+            "subnet_mapping": [
+              {
+                "allocation_id": "",
+                "ipv6_address": "",
+                "outpost_id": "",
+                "private_ipv4_address": "",
+                "subnet_id": "subnet-0a2b4b43925401a30"
+              },
+              {
+                "allocation_id": "",
+                "ipv6_address": "",
+                "outpost_id": "",
+                "private_ipv4_address": "",
+                "subnet_id": "subnet-0c3b58546b6dff7dd"
+              }
+            ],
+            "subnets": [
+              "subnet-0a2b4b43925401a30",
+              "subnet-0c3b58546b6dff7dd"
+            ],
+            "tags": {
+              "Name": "stock-analyzer-alb"
+            },
+            "tags_all": {
+              "Name": "stock-analyzer-alb"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a",
+            "xff_header_processing_mode": "append",
+            "zone_id": "Z3AADJGX6KTTL2"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener",
+      "name": "http",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "alpn_policy": null,
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [
+                  {
+                    "content_type": "text/plain",
+                    "message_body": "Default backend reached",
+                    "status_code": "404"
+                  }
+                ],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "",
+                "type": "fixed-response"
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:loadbalancer/app/stock-analyzer-alb/f81c590316270958",
+            "mutual_authentication": [],
+            "port": 80,
+            "protocol": "HTTP",
+            "routing_http_request_x_amzn_mtls_clientcert_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_issuer_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_leaf_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_subject_header_name": null,
+            "routing_http_request_x_amzn_mtls_clientcert_validity_header_name": null,
+            "routing_http_request_x_amzn_tls_cipher_suite_header_name": null,
+            "routing_http_request_x_amzn_tls_version_header_name": null,
+            "routing_http_response_access_control_allow_credentials_header_value": "",
+            "routing_http_response_access_control_allow_headers_header_value": "",
+            "routing_http_response_access_control_allow_methods_header_value": "",
+            "routing_http_response_access_control_allow_origin_header_value": "",
+            "routing_http_response_access_control_expose_headers_header_value": "",
+            "routing_http_response_access_control_max_age_header_value": "",
+            "routing_http_response_content_security_policy_header_value": "",
+            "routing_http_response_server_enabled": true,
+            "routing_http_response_strict_transport_security_header_value": "",
+            "routing_http_response_x_content_type_options_header_value": "",
+            "routing_http_response_x_frame_options_header_value": "",
+            "ssl_policy": "",
+            "tags": null,
+            "tags_all": {},
+            "tcp_idle_timeout_seconds": null,
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "backend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/predict"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/ccb8e05be8c1d71a",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "priority": 101,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.http",
+            "module.network.aws_lb_target_group.backend",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_listener_rule",
+      "name": "frontend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "order": 1,
+                "redirect": [],
+                "target_group_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+                "type": "forward"
+              }
+            ],
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "values": [
+                      "/"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener-rule/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8/fb1a1735da021d67",
+            "listener_arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:listener/app/stock-analyzer-alb/f81c590316270958/721e4c7e4e1964b8",
+            "priority": 100,
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_lb.main",
+            "module.network.aws_lb_listener.http",
+            "module.network.aws_lb_target_group.frontend",
+            "module.network.aws_security_group.alb",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_target_group",
+      "name": "backend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "arn_suffix": "targetgroup/backend-tg/4bb7268be23e80db",
+            "connection_termination": null,
+            "deregistration_delay": "300",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "matcher": "200",
+                "path": "/predict",
+                "port": "traffic-port",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/backend-tg/4bb7268be23e80db",
+            "ip_address_type": "ipv4",
+            "lambda_multi_value_headers_enabled": false,
+            "load_balancer_arns": [],
+            "load_balancing_algorithm_type": "round_robin",
+            "load_balancing_anomaly_mitigation": "off",
+            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
+            "name": "backend-tg",
+            "name_prefix": "",
+            "port": 8000,
+            "preserve_client_ip": null,
+            "protocol": "HTTP",
+            "protocol_version": "HTTP1",
+            "proxy_protocol_v2": false,
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 86400,
+                "cookie_name": "",
+                "enabled": false,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "target_failover": [
+              {
+                "on_deregistration": null,
+                "on_unhealthy": null
+              }
+            ],
+            "target_group_health": [
+              {
+                "dns_failover": [
+                  {
+                    "minimum_healthy_targets_count": "1",
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ],
+                "unhealthy_state_routing": [
+                  {
+                    "minimum_healthy_targets_count": 1,
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ]
+              }
+            ],
+            "target_health_state": [
+              {
+                "enable_unhealthy_connection_termination": null,
+                "unhealthy_draining_interval": null
+              }
+            ],
+            "target_type": "ip",
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_lb_target_group",
+      "name": "frontend",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "arn_suffix": "targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "connection_termination": null,
+            "deregistration_delay": "300",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "matcher": "200",
+                "path": "/",
+                "port": "traffic-port",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "id": "arn:aws:elasticloadbalancing:us-east-2:896924684176:targetgroup/frontend-tg/a7cbb8881f90f7e4",
+            "ip_address_type": "ipv4",
+            "lambda_multi_value_headers_enabled": false,
+            "load_balancer_arns": [],
+            "load_balancing_algorithm_type": "round_robin",
+            "load_balancing_anomaly_mitigation": "off",
+            "load_balancing_cross_zone_enabled": "use_load_balancer_configuration",
+            "name": "frontend-tg",
+            "name_prefix": "",
+            "port": 80,
+            "preserve_client_ip": null,
+            "protocol": "HTTP",
+            "protocol_version": "HTTP1",
+            "proxy_protocol_v2": false,
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 86400,
+                "cookie_name": "",
+                "enabled": false,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "target_failover": [
+              {
+                "on_deregistration": null,
+                "on_unhealthy": null
+              }
+            ],
+            "target_group_health": [
+              {
+                "dns_failover": [
+                  {
+                    "minimum_healthy_targets_count": "1",
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ],
+                "unhealthy_state_routing": [
+                  {
+                    "minimum_healthy_targets_count": 1,
+                    "minimum_healthy_targets_percentage": "off"
+                  }
+                ]
+              }
+            ],
+            "target_health_state": [
+              {
+                "enable_unhealthy_connection_termination": null,
+                "unhealthy_draining_interval": null
+              }
+            ],
+            "target_type": "ip",
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "internet_access",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": "",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "",
+            "gateway_id": "igw-0fa0bc93b789a7643",
+            "id": "r-rtb-0c3bad089d9c13adc1080289494",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "state": "active",
+            "timeouts": null,
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_internet_gateway.gw",
+            "module.network.aws_route_table.public",
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:route-table/rtb-0c3bad089d9c13adc",
+            "id": "rtb-0c3bad089d9c13adc",
+            "owner_id": "896924684176",
+            "propagating_vgws": [],
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "igw-0fa0bc93b789a7643",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-0644356cbf9fcd16a",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "subnet_id": "subnet-0a2b4b43925401a30",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_route_table.public",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-061959307ae8430b0",
+            "route_table_id": "rtb-0c3bad089d9c13adc",
+            "subnet_id": "subnet-0c3b58546b6dff7dd",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.network.aws_route_table.public",
+            "module.network.aws_subnet.public",
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "alb",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:security-group/sg-0849043bdcac304cd",
+            "description": "Allow HTTP/HTTPS inbound traffic",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-0849043bdcac304cd",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 443
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "alb-sg",
+            "name_prefix": "",
+            "owner_id": "896924684176",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "alb-sg"
+            },
+            "tags_all": {
+              "Name": "alb-sg"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.network.aws_vpc.main"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0a2b4b43925401a30",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2a",
+            "availability_zone_id": "use2-az1",
+            "cidr_block": "10.0.0.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0a2b4b43925401a30",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": true,
+            "outpost_arn": "",
+            "owner_id": "896924684176",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "stock-public-0"
+            },
+            "tags_all": {
+              "Name": "stock-public-0"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:subnet/subnet-0c3b58546b6dff7dd",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2b",
+            "availability_zone_id": "use2-az2",
+            "cidr_block": "10.0.16.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0c3b58546b6dff7dd",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": true,
+            "outpost_arn": "",
+            "owner_id": "896924684176",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "stock-public-1"
+            },
+            "tags_all": {
+              "Name": "stock-public-1"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0e677828b4dc5fa9a"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.network.aws_vpc.main",
+            "module.network.data.aws_availability_zones.available"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.network",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "provider": "module.network.provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:896924684176:vpc/vpc-0e677828b4dc5fa9a",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-0686f8d4be1e2c8dc",
+            "default_route_table_id": "rtb-0509e12dac3222b5d",
+            "default_security_group_id": "sg-010ecb86c454dda99",
+            "dhcp_options_id": "dopt-08834e4367484cb08",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-0e677828b4dc5fa9a",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-0509e12dac3222b5d",
+            "owner_id": "896924684176",
+            "tags": {
+              "Name": "stock-vpc"
+            },
+            "tags_all": {
+              "Name": "stock-vpc"
+            }
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
Frontend -> CloudFront + S3 (Static hosting for React+Vite app). This makes it cheaper, better availability, less maintenance and inbuilt security. 
Backend -> ECS service to provide separation of concerns. This helps maintain independence between frontend and backend modules redirect backend API traffic via a separate ALB for ECS.